### PR TITLE
Remove "strictly" for graphql-java and upgrade to Boot 3.3.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,7 @@ allprojects {
     // and suggest an upgrade. The only exception currently are those defined
     // in buildSrc, most likely because the variables are used in plugins as well
     // as dependencies. e.g. KOTLIN_VERSION
-    extra["sb.version"] = "3.3.5"
+    extra["sb.version"] = "3.3.6"
     extra["kotlin.version"] = Versions.KOTLIN_VERSION
 }
 val internalBomModules by extra(

--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -214,7 +214,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -308,7 +308,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3552,7 +3552,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3646,7 +3646,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -1,15 +1,15 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2"
+            "locked": "2.17.3"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.9.0"
@@ -21,7 +21,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11"
+            "locked": "3.6.12"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.25"
@@ -29,19 +29,19 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2"
+            "locked": "2.17.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2"
+            "locked": "2.17.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2"
+            "locked": "2.17.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2"
+            "locked": "2.17.3"
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2"
+            "locked": "2.17.3"
         },
         "com.graphql-java:graphql-java": {
             "locked": "22.3"
@@ -56,41 +56,41 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11"
+            "locked": "3.6.12"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.25"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0"
+            "locked": "26.0.1"
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "compileOnlyDependenciesMetadata": {
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2"
+            "locked": "2.17.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2"
+            "locked": "2.17.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2"
+            "locked": "2.17.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2"
+            "locked": "2.17.3"
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2"
+            "locked": "2.17.3"
         },
         "com.graphql-java:graphql-java": {
             "locked": "22.3"
@@ -105,16 +105,16 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11"
+            "locked": "3.6.12"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.25"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0"
+            "locked": "26.0.1"
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmh": {
@@ -135,19 +135,19 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2"
+            "locked": "2.17.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2"
+            "locked": "2.17.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2"
+            "locked": "2.17.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2"
+            "locked": "2.17.3"
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2"
+            "locked": "2.17.3"
         },
         "com.graphql-java:graphql-java": {
             "locked": "22.3"
@@ -162,13 +162,13 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11"
+            "locked": "3.6.12"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.25"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0"
+            "locked": "26.0.1"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -180,10 +180,10 @@
             "locked": "1.36"
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -202,13 +202,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -221,7 +221,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -231,7 +231,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -241,7 +241,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -252,7 +252,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
@@ -260,7 +260,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -270,7 +270,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -283,14 +283,14 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -314,7 +314,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -484,13 +484,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -557,7 +557,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -574,7 +574,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -586,13 +586,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -600,19 +600,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -632,7 +632,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -641,13 +641,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -655,7 +655,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -663,20 +663,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -692,20 +692,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -714,19 +714,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
@@ -739,7 +739,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -791,7 +791,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -842,20 +842,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -968,7 +968,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
@@ -1127,7 +1127,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1136,7 +1136,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
@@ -1147,7 +1147,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
@@ -1158,61 +1158,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1222,7 +1222,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1231,7 +1231,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1248,27 +1248,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
@@ -1287,13 +1287,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
@@ -1304,7 +1304,7 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
@@ -1630,7 +1630,7 @@
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1640,7 +1640,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1650,7 +1650,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1660,31 +1660,31 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1728,20 +1728,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1772,7 +1772,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
@@ -1798,13 +1798,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1812,13 +1812,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -1829,25 +1829,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -1855,19 +1855,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1877,7 +1877,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1887,7 +1887,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1898,34 +1898,34 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2058,13 +2058,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2129,7 +2129,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2146,7 +2146,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -2158,13 +2158,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2172,19 +2172,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -2204,7 +2204,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -2213,13 +2213,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -2227,7 +2227,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -2235,20 +2235,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2264,20 +2264,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -2286,19 +2286,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -2308,7 +2308,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2374,20 +2374,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -2447,7 +2447,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
@@ -2550,7 +2550,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2559,14 +2559,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -2575,61 +2575,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2639,14 +2639,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2662,27 +2662,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -2692,13 +2692,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -2718,19 +2718,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2740,7 +2740,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2750,7 +2750,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2761,34 +2761,34 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2921,13 +2921,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2962,7 +2962,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2979,7 +2979,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -2991,13 +2991,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3005,19 +3005,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -3037,7 +3037,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -3046,13 +3046,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -3060,7 +3060,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -3068,20 +3068,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -3097,20 +3097,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -3119,19 +3119,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -3141,7 +3141,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3205,20 +3205,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3278,7 +3278,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0"
+            "locked": "26.0.1"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "5.10.5",
@@ -3372,7 +3372,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3381,14 +3381,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -3397,61 +3397,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3461,14 +3461,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3484,27 +3484,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3514,13 +3514,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -3540,13 +3540,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3559,7 +3559,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3569,7 +3569,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3579,7 +3579,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3590,7 +3590,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
@@ -3598,7 +3598,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3608,7 +3608,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3621,14 +3621,14 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3652,7 +3652,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3822,13 +3822,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3895,7 +3895,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -3912,7 +3912,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -3924,13 +3924,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3938,19 +3938,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -3970,7 +3970,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -3979,13 +3979,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -3993,7 +3993,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -4001,20 +4001,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4030,20 +4030,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -4052,19 +4052,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
@@ -4077,7 +4077,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -4129,7 +4129,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -4168,20 +4168,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -4294,7 +4294,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
@@ -4424,7 +4424,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4433,7 +4433,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
@@ -4444,7 +4444,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
@@ -4455,61 +4455,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4519,7 +4519,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -4528,7 +4528,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4545,27 +4545,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
@@ -4584,13 +4584,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
@@ -4601,7 +4601,7 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",

--- a/graphql-dgs-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-example-java-webflux/dependencies.lock
@@ -1943,7 +1943,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2037,7 +2037,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3352,7 +3352,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3446,7 +3446,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -5779,7 +5779,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -5873,7 +5873,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-example-java-webflux/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -17,19 +17,19 @@
     },
     "compileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -39,7 +39,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -49,7 +49,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -59,28 +59,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -237,20 +237,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -267,7 +267,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -279,13 +279,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -293,19 +293,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -325,7 +325,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -334,13 +334,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -348,7 +348,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -356,20 +356,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -385,20 +385,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -407,19 +407,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -495,57 +495,57 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -554,13 +554,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -573,19 +573,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -593,7 +593,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -607,19 +607,19 @@
     },
     "implementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -629,7 +629,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -639,7 +639,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -649,28 +649,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -827,20 +827,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -857,7 +857,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -869,13 +869,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -883,19 +883,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -915,7 +915,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -924,13 +924,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -938,7 +938,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -946,20 +946,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -975,20 +975,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -997,19 +997,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1079,57 +1079,57 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1138,13 +1138,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1157,19 +1157,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -1177,7 +1177,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -1244,19 +1244,19 @@
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1266,7 +1266,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1276,7 +1276,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1286,28 +1286,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1464,20 +1464,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -1494,7 +1494,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -1506,13 +1506,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1520,19 +1520,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -1552,7 +1552,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -1561,13 +1561,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -1575,7 +1575,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -1583,20 +1583,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -1612,20 +1612,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -1634,19 +1634,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1768,57 +1768,57 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1827,13 +1827,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1846,19 +1846,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -1866,7 +1866,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -1931,13 +1931,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1950,7 +1950,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1961,7 +1961,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1971,7 +1971,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1983,7 +1983,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1991,7 +1991,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2000,7 +2000,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2011,7 +2011,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2019,7 +2019,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2043,7 +2043,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2217,13 +2217,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2302,7 +2302,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -2320,7 +2320,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-dns",
@@ -2333,13 +2333,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2347,19 +2347,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-buffer",
@@ -2380,7 +2380,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-http",
@@ -2390,13 +2390,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -2404,7 +2404,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -2412,20 +2412,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -2442,20 +2442,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -2470,19 +2470,19 @@
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
-            "locked": "0.1.23",
+            "locked": "0.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
@@ -2490,14 +2490,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -2549,7 +2549,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2708,7 +2708,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -2868,7 +2868,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2877,7 +2877,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -2886,7 +2886,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
@@ -2896,53 +2896,53 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2951,7 +2951,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -2960,7 +2960,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2976,26 +2976,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3009,14 +3009,14 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -3340,13 +3340,13 @@
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3359,7 +3359,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3370,7 +3370,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3380,7 +3380,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3392,7 +3392,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3400,7 +3400,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3409,7 +3409,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3420,7 +3420,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3428,7 +3428,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3452,7 +3452,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3619,13 +3619,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3644,7 +3644,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -3662,7 +3662,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-dns",
@@ -3675,13 +3675,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3689,19 +3689,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-buffer",
@@ -3722,7 +3722,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-http",
@@ -3732,13 +3732,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -3746,7 +3746,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -3754,20 +3754,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -3784,20 +3784,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -3812,19 +3812,19 @@
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
-            "locked": "0.1.23",
+            "locked": "0.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
@@ -3832,14 +3832,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -3858,7 +3858,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -3965,7 +3965,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -4005,14 +4005,14 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -4020,7 +4020,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
@@ -4029,37 +4029,37 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4068,7 +4068,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -4077,7 +4077,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4091,19 +4091,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4117,14 +4117,14 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -4139,19 +4139,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4161,7 +4161,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -4171,7 +4171,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4181,28 +4181,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4366,13 +4366,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -4437,7 +4437,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4454,7 +4454,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -4466,13 +4466,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4480,19 +4480,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -4512,7 +4512,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -4521,13 +4521,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -4535,7 +4535,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -4543,20 +4543,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4572,20 +4572,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -4594,19 +4594,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4828,7 +4828,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4837,14 +4837,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -4852,53 +4852,53 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4907,13 +4907,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4928,26 +4928,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -4955,7 +4955,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -4975,19 +4975,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4997,7 +4997,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -5007,7 +5007,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5017,28 +5017,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -5202,13 +5202,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -5243,7 +5243,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -5260,7 +5260,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -5272,13 +5272,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5286,19 +5286,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -5318,7 +5318,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -5327,13 +5327,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -5341,7 +5341,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -5349,20 +5349,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -5378,20 +5378,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -5400,19 +5400,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -5620,7 +5620,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -5629,14 +5629,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -5644,53 +5644,53 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5699,13 +5699,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -5720,26 +5720,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -5747,7 +5747,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -5767,13 +5767,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -5786,7 +5786,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5797,7 +5797,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -5807,7 +5807,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5819,7 +5819,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -5827,7 +5827,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -5836,7 +5836,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -5847,7 +5847,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -5855,7 +5855,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -5879,7 +5879,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -6053,13 +6053,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -6138,7 +6138,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -6156,7 +6156,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-dns",
@@ -6169,13 +6169,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -6183,19 +6183,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-buffer",
@@ -6216,7 +6216,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-http",
@@ -6226,13 +6226,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -6240,7 +6240,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -6248,20 +6248,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -6278,20 +6278,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -6306,19 +6306,19 @@
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
-            "locked": "0.1.23",
+            "locked": "0.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
@@ -6326,14 +6326,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -6385,7 +6385,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -6532,7 +6532,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -6663,7 +6663,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -6672,7 +6672,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -6681,7 +6681,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
@@ -6691,53 +6691,53 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -6746,7 +6746,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -6755,7 +6755,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -6771,26 +6771,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -6804,14 +6804,14 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -17,19 +17,19 @@
     },
     "compileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -39,7 +39,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -49,7 +49,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -59,28 +59,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -252,7 +252,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -260,19 +260,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -282,7 +282,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -310,20 +310,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -382,7 +382,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -391,26 +391,26 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -418,38 +418,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -458,14 +458,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -478,20 +478,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -499,7 +499,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -513,19 +513,19 @@
     },
     "implementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -535,7 +535,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -545,7 +545,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -555,28 +555,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -748,7 +748,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -756,19 +756,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -778,7 +778,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -806,20 +806,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -872,7 +872,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -881,26 +881,26 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -908,38 +908,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -948,14 +948,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -968,20 +968,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -989,7 +989,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -1056,19 +1056,19 @@
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1078,7 +1078,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1088,7 +1088,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1098,28 +1098,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1291,7 +1291,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -1299,19 +1299,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -1321,7 +1321,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1361,20 +1361,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1467,7 +1467,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -1476,26 +1476,26 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -1503,38 +1503,38 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1543,14 +1543,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1563,20 +1563,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -1584,7 +1584,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -1649,13 +1649,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1668,7 +1668,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1679,7 +1679,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1689,7 +1689,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1702,7 +1702,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1710,7 +1710,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1722,7 +1722,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1734,7 +1734,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1742,7 +1742,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1778,7 +1778,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1955,7 +1955,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.1",
+            "locked": "1.8.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -1981,7 +1981,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -1989,20 +1989,20 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -2072,7 +2072,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2089,7 +2089,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -2101,13 +2101,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2115,19 +2115,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -2147,7 +2147,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -2156,13 +2156,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -2170,7 +2170,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -2178,20 +2178,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2207,20 +2207,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -2229,19 +2229,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -2254,7 +2254,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2306,7 +2306,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2357,20 +2357,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -2497,7 +2497,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -2664,7 +2664,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -2675,19 +2675,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -2699,7 +2699,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
@@ -2711,74 +2711,74 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2790,7 +2790,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -2801,13 +2801,13 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2826,33 +2826,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2869,20 +2869,20 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
@@ -3209,13 +3209,13 @@
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3228,7 +3228,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3239,7 +3239,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3249,7 +3249,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3262,7 +3262,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3270,7 +3270,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3282,7 +3282,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3294,7 +3294,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3302,7 +3302,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3338,7 +3338,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3514,7 +3514,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.1",
+            "locked": "1.8.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -3534,7 +3534,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -3542,20 +3542,20 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -3565,7 +3565,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -3587,7 +3587,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -3625,20 +3625,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3726,7 +3726,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -3773,7 +3773,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -3782,19 +3782,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -3805,7 +3805,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
@@ -3815,48 +3815,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3867,7 +3867,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -3878,13 +3878,13 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3900,26 +3900,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3934,14 +3934,14 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
@@ -3959,19 +3959,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3981,7 +3981,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3991,7 +3991,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4001,28 +4001,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4201,7 +4201,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -4209,19 +4209,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -4289,7 +4289,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4306,7 +4306,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -4318,13 +4318,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4332,19 +4332,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -4364,7 +4364,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -4373,13 +4373,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -4387,7 +4387,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -4395,20 +4395,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4424,20 +4424,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -4446,19 +4446,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4469,7 +4469,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -4535,20 +4535,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -4714,7 +4714,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -4725,19 +4725,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4745,7 +4745,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -4755,64 +4755,64 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4822,14 +4822,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4845,27 +4845,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -4875,13 +4875,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -4901,19 +4901,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4923,7 +4923,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -4933,7 +4933,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4943,28 +4943,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -5143,7 +5143,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -5151,19 +5151,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -5201,7 +5201,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -5218,7 +5218,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -5230,13 +5230,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5244,19 +5244,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -5276,7 +5276,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -5285,13 +5285,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -5299,7 +5299,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -5307,20 +5307,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -5336,20 +5336,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -5358,19 +5358,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -5381,7 +5381,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -5445,20 +5445,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -5612,7 +5612,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -5623,19 +5623,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -5643,7 +5643,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -5653,64 +5653,64 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5720,14 +5720,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -5743,27 +5743,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -5773,13 +5773,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -5799,13 +5799,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -5818,7 +5818,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5829,7 +5829,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -5839,7 +5839,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5852,7 +5852,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -5860,7 +5860,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -5872,7 +5872,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -5884,7 +5884,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -5892,7 +5892,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -5928,7 +5928,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -6105,7 +6105,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.1",
+            "locked": "1.8.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -6131,7 +6131,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -6139,20 +6139,20 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -6222,7 +6222,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -6239,7 +6239,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -6251,13 +6251,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -6265,19 +6265,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -6297,7 +6297,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -6306,13 +6306,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -6320,7 +6320,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -6328,20 +6328,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -6357,20 +6357,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -6379,19 +6379,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -6404,7 +6404,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -6456,7 +6456,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -6495,20 +6495,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -6635,7 +6635,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -6773,7 +6773,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -6784,19 +6784,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -6808,7 +6808,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
@@ -6820,74 +6820,74 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -6899,7 +6899,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -6910,13 +6910,13 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -6935,33 +6935,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -6978,20 +6978,20 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -1661,7 +1661,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1772,7 +1772,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3221,7 +3221,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3332,7 +3332,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -5811,7 +5811,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -5922,7 +5922,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -818,7 +818,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -881,7 +881,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1880,7 +1880,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1943,7 +1943,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3369,7 +3369,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3432,7 +3432,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -17,27 +17,27 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -138,20 +138,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -188,13 +188,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -202,10 +202,10 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -215,44 +215,44 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -353,20 +353,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -397,13 +397,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -411,10 +411,10 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -424,19 +424,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmh": {
@@ -494,27 +494,27 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -615,20 +615,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -711,13 +711,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -725,10 +725,10 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -738,19 +738,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -806,13 +806,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -825,7 +825,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -834,7 +834,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -842,7 +842,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -850,14 +850,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -865,7 +865,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -887,7 +887,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1004,13 +1004,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1077,7 +1077,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
@@ -1085,7 +1085,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1130,7 +1130,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1441,7 +1441,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1450,7 +1450,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -1459,42 +1459,42 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1502,14 +1502,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1523,26 +1523,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
@@ -1868,13 +1868,13 @@
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1887,7 +1887,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1896,7 +1896,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1904,7 +1904,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -1912,14 +1912,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1927,7 +1927,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1949,7 +1949,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2059,20 +2059,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -2085,7 +2085,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2224,14 +2224,14 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -2239,25 +2239,25 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2265,14 +2265,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2284,19 +2284,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
@@ -2313,39 +2313,39 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2453,13 +2453,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2524,14 +2524,14 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test"
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2743,7 +2743,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2752,48 +2752,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2801,13 +2801,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2821,26 +2821,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -2857,39 +2857,39 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2997,13 +2997,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3038,14 +3038,14 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test"
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3243,7 +3243,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3252,48 +3252,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3301,13 +3301,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3321,26 +3321,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -3357,13 +3357,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3376,7 +3376,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3385,7 +3385,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3393,7 +3393,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -3401,14 +3401,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3416,7 +3416,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3438,7 +3438,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3555,13 +3555,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3628,7 +3628,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
@@ -3636,7 +3636,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3681,7 +3681,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -3951,7 +3951,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3960,7 +3960,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -3969,42 +3969,42 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4012,14 +4012,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4033,26 +4033,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -147,13 +147,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -185,35 +185,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -223,13 +223,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -295,13 +295,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -327,35 +327,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -365,13 +365,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -490,13 +490,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -574,35 +574,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -612,13 +612,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -677,13 +677,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -696,7 +696,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -707,7 +707,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -717,7 +717,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -728,7 +728,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -736,7 +736,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -746,7 +746,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -756,7 +756,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -764,7 +764,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -788,7 +788,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -925,13 +925,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -998,7 +998,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1052,7 +1052,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1103,20 +1103,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1225,7 +1225,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -1385,7 +1385,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1394,14 +1394,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
@@ -1411,61 +1411,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1475,7 +1475,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1484,7 +1484,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1501,33 +1501,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1540,14 +1540,14 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "org.springframework.boot:spring-boot-starter-websocket"
@@ -1879,7 +1879,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1888,7 +1888,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1896,7 +1896,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -1904,21 +1904,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1940,7 +1940,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2013,27 +2013,27 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2138,22 +2138,22 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2161,14 +2161,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -2179,19 +2179,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
@@ -2205,19 +2205,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2225,7 +2225,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
@@ -2351,13 +2351,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -2421,7 +2421,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2636,7 +2636,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2645,61 +2645,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2712,19 +2712,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
@@ -2745,19 +2745,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2765,7 +2765,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
@@ -2891,13 +2891,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -2931,7 +2931,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3132,7 +3132,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3141,61 +3141,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3208,19 +3208,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
@@ -3241,13 +3241,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3260,7 +3260,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3271,7 +3271,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3281,7 +3281,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3292,7 +3292,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3300,7 +3300,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3310,7 +3310,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3320,7 +3320,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3328,7 +3328,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3352,7 +3352,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3489,13 +3489,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3562,7 +3562,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3616,7 +3616,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -3655,20 +3655,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3777,7 +3777,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -3908,7 +3908,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3917,14 +3917,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
@@ -3934,61 +3934,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3998,7 +3998,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -4007,7 +4007,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4024,33 +4024,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4063,14 +4063,14 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "org.springframework.boot:spring-boot-starter-websocket"

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -689,7 +689,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -782,7 +782,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1872,7 +1872,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1934,7 +1934,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3253,7 +3253,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3346,7 +3346,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-extended-validation/dependencies.lock
+++ b/graphql-dgs-extended-validation/dependencies.lock
@@ -865,7 +865,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -964,7 +964,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2092,7 +2092,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2160,7 +2160,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3605,7 +3605,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3704,7 +3704,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-extended-validation/dependencies.lock
+++ b/graphql-dgs-extended-validation/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -205,13 +205,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -273,35 +273,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -311,13 +311,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -397,13 +397,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -459,35 +459,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -497,13 +497,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -636,13 +636,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -750,35 +750,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -788,13 +788,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -853,13 +853,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -872,7 +872,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -883,7 +883,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -893,7 +893,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -904,7 +904,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -912,7 +912,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -922,7 +922,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -932,7 +932,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -940,7 +940,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -970,7 +970,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1115,13 +1115,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1188,7 +1188,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1254,7 +1254,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1305,20 +1305,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1445,7 +1445,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -1605,7 +1605,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1614,14 +1614,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
@@ -1631,61 +1631,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1695,7 +1695,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1704,7 +1704,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1721,33 +1721,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1760,14 +1760,14 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "org.springframework.boot:spring-boot-starter-websocket"
@@ -2099,7 +2099,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2108,7 +2108,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2116,7 +2116,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2124,21 +2124,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2166,7 +2166,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2247,20 +2247,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -2279,7 +2279,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2402,22 +2402,22 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2425,14 +2425,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -2443,19 +2443,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
@@ -2469,19 +2469,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2489,7 +2489,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
@@ -2629,13 +2629,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -2699,7 +2699,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2944,7 +2944,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2953,61 +2953,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3020,19 +3020,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
@@ -3053,19 +3053,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3073,7 +3073,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
@@ -3213,13 +3213,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -3253,7 +3253,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3484,7 +3484,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3493,61 +3493,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3560,19 +3560,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
@@ -3593,13 +3593,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3612,7 +3612,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3623,7 +3623,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3633,7 +3633,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3644,7 +3644,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3652,7 +3652,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3662,7 +3662,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3672,7 +3672,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3680,7 +3680,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3710,7 +3710,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3855,13 +3855,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3928,7 +3928,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3994,7 +3994,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -4033,20 +4033,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -4173,7 +4173,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -4304,7 +4304,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4313,14 +4313,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
@@ -4330,61 +4330,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4394,7 +4394,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -4403,7 +4403,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4420,33 +4420,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4459,14 +4459,14 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "org.springframework.boot:spring-boot-starter-websocket"

--- a/graphql-dgs-mocking/dependencies.lock
+++ b/graphql-dgs-mocking/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -48,7 +48,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -70,7 +70,7 @@
             "project": true
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0"
+            "locked": "2.4.2"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.25"
@@ -108,7 +108,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -130,7 +130,7 @@
             "project": true
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0"
+            "locked": "2.4.2"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.25"
@@ -215,7 +215,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -237,7 +237,7 @@
             "project": true
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0"
+            "locked": "2.4.2"
         },
         "net.sf.jopt-simple:jopt-simple": {
             "locked": "5.0.4",
@@ -366,13 +366,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -384,7 +384,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -419,13 +419,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -530,7 +530,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0"
+            "locked": "2.4.2"
         },
         "net.minidev:accessors-smart": {
             "locked": "2.5.1",
@@ -797,7 +797,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -806,61 +806,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -873,19 +873,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
@@ -1216,7 +1216,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1238,7 +1238,7 @@
             "project": true
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0"
+            "locked": "2.4.2"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.25"
@@ -1270,13 +1270,13 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1288,7 +1288,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1323,13 +1323,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -1426,7 +1426,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0"
+            "locked": "2.4.2"
         },
         "net.minidev:accessors-smart": {
             "locked": "2.5.1",
@@ -1594,7 +1594,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1603,61 +1603,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1670,19 +1670,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
@@ -1704,13 +1704,13 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1722,7 +1722,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1757,13 +1757,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -1828,7 +1828,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0"
+            "locked": "2.4.2"
         },
         "net.minidev:accessors-smart": {
             "locked": "2.5.1",
@@ -1984,7 +1984,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1993,61 +1993,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2060,19 +2060,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
@@ -2094,13 +2094,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2112,7 +2112,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2147,13 +2147,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -2258,7 +2258,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0"
+            "locked": "2.4.2"
         },
         "net.minidev:accessors-smart": {
             "locked": "2.5.1",
@@ -2484,7 +2484,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2493,61 +2493,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2560,19 +2560,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -665,7 +665,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -727,7 +727,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1647,7 +1647,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1709,7 +1709,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2843,7 +2843,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2905,7 +2905,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -135,13 +135,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -173,35 +173,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -211,13 +211,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -277,13 +277,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -309,35 +309,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -347,13 +347,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -466,13 +466,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -550,35 +550,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -588,13 +588,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -653,13 +653,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -672,7 +672,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -681,7 +681,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -689,7 +689,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -697,21 +697,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -733,7 +733,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -806,13 +806,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -879,7 +879,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -925,7 +925,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1225,7 +1225,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1234,48 +1234,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1283,14 +1283,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1304,26 +1304,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
@@ -1654,7 +1654,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1663,7 +1663,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1671,7 +1671,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -1679,21 +1679,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1715,7 +1715,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1781,27 +1781,27 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1906,22 +1906,22 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1929,14 +1929,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -1947,19 +1947,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
@@ -1973,13 +1973,13 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2044,13 +2044,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -2315,7 +2315,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2324,61 +2324,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2391,19 +2391,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
@@ -2424,13 +2424,13 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2495,13 +2495,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -2722,7 +2722,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2731,61 +2731,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2798,19 +2798,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
@@ -2831,13 +2831,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2850,7 +2850,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2859,7 +2859,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2867,7 +2867,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2875,21 +2875,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2911,7 +2911,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2984,13 +2984,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3057,7 +3057,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -3103,7 +3103,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -3362,7 +3362,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3371,48 +3371,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3420,14 +3420,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3441,26 +3441,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]

--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -49,32 +49,30 @@ dependencies {
         // GraphQL Platform
         api("com.graphql-java:graphql-java") {
             version {
-                prefer("22.3")
+                require("22.3")
                 reject("[20.6, 19.5, 18.2]")
             }
 
         }
         api("com.graphql-java:java-dataloader") {
             version {
-                prefer("3.3.0")
+                require("3.3.0")
                 reject("[3.2.1]")
             }
 
         }
         api("com.graphql-java:graphql-java-extended-scalars") {
             version {
-                 strictly("[22.0]")
-                 prefer("22.0")
+                require("22.0")
                  reject("20.2")
             }
         }
         api("com.graphql-java:graphql-java-extended-validation") {
-            version { strictly("22.0") }
+            version { require("22.0") }
         }
         api("com.apollographql.federation:federation-graphql-java-support") {
             version {
-                strictly("[5.0.0]")
-                prefer("5.0.0")
+                require("5.2.0")
             }
         }
         // ---

--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -49,15 +49,13 @@ dependencies {
         // GraphQL Platform
         api("com.graphql-java:graphql-java") {
             version {
-                strictly("22.1")
-                prefer("22.1")
+                prefer("22.3")
                 reject("[20.6, 19.5, 18.2]")
             }
 
         }
         api("com.graphql-java:java-dataloader") {
             version {
-                strictly("[3.3.0]")
                 prefer("3.3.0")
                 reject("[3.2.1]")
             }

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -1135,7 +1135,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1198,7 +1198,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2160,7 +2160,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2222,7 +2222,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3553,7 +3553,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3616,7 +3616,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -83,19 +83,19 @@
     },
     "compileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -103,27 +103,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -184,13 +184,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -200,7 +200,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -292,35 +292,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -329,13 +329,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -348,25 +348,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
@@ -377,32 +377,32 @@
     },
     "compileOnlyDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "org.springframework:spring-webflux"
             ]
@@ -446,35 +446,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -483,13 +483,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -502,25 +502,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
@@ -531,7 +531,7 @@
     },
     "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -539,27 +539,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -623,7 +623,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions"
@@ -732,19 +732,19 @@
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -752,27 +752,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -833,13 +833,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -849,7 +849,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -987,35 +987,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1024,13 +1024,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1043,25 +1043,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
@@ -1123,13 +1123,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1142,7 +1142,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1151,7 +1151,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1159,7 +1159,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -1167,14 +1167,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1182,7 +1182,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1204,7 +1204,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1296,13 +1296,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1372,7 +1372,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -1381,7 +1381,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1426,7 +1426,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1735,7 +1735,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1744,49 +1744,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1794,14 +1794,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1815,26 +1815,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
@@ -2167,7 +2167,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2176,7 +2176,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2184,7 +2184,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2192,21 +2192,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2228,7 +2228,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2294,13 +2294,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2310,7 +2310,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -2318,7 +2318,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2423,13 +2423,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2437,13 +2437,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -2453,19 +2453,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
@@ -2479,19 +2479,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2499,27 +2499,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2605,13 +2605,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -2678,7 +2678,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -2686,7 +2686,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2924,7 +2924,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2933,61 +2933,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3000,19 +3000,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
@@ -3033,19 +3033,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -3053,27 +3053,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3159,13 +3159,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -3202,7 +3202,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -3210,7 +3210,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3432,7 +3432,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3441,61 +3441,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3508,19 +3508,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
@@ -3541,13 +3541,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3560,7 +3560,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3569,7 +3569,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3577,7 +3577,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -3585,14 +3585,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3600,7 +3600,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3622,7 +3622,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3714,13 +3714,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3790,7 +3790,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -3799,7 +3799,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3844,7 +3844,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -4112,7 +4112,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4121,49 +4121,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4171,14 +4171,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4192,26 +4192,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -1681,7 +1681,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1785,7 +1785,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2916,7 +2916,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2987,7 +2987,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -4614,7 +4614,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -4718,7 +4718,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -83,19 +83,19 @@
     },
     "compileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -105,7 +105,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -115,7 +115,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -125,28 +125,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -273,23 +273,23 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.1"
+            "locked": "1.8.2"
         },
         "commons-codec:commons-codec": {
             "locked": "1.16.1"
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6"
+            "locked": "1.13.8"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -297,7 +297,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -325,20 +325,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -392,7 +392,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -401,58 +401,58 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -462,7 +462,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-context-support",
@@ -470,10 +470,10 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -487,20 +487,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -508,7 +508,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -522,19 +522,19 @@
     },
     "compileOnlyDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -544,7 +544,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -554,7 +554,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -564,28 +564,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -703,20 +703,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -744,20 +744,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -799,7 +799,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -808,58 +808,58 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -868,14 +868,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -888,20 +888,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -909,7 +909,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -984,23 +984,23 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.1"
+            "locked": "1.8.2"
         },
         "commons-codec:commons-codec": {
             "locked": "1.16.1"
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6"
+            "locked": "1.13.8"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context"
@@ -1033,13 +1033,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1047,16 +1047,16 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context-support"
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -1066,13 +1066,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -1133,19 +1133,19 @@
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1155,7 +1155,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1165,7 +1165,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1175,28 +1175,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1323,23 +1323,23 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.1"
+            "locked": "1.8.2"
         },
         "commons-codec:commons-codec": {
             "locked": "1.16.1"
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6"
+            "locked": "1.13.8"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -1347,7 +1347,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1387,20 +1387,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1488,7 +1488,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -1497,58 +1497,58 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1558,7 +1558,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-context-support",
@@ -1566,10 +1566,10 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1583,20 +1583,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -1604,7 +1604,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -1669,13 +1669,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1688,7 +1688,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1699,7 +1699,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1709,7 +1709,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1721,7 +1721,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1729,7 +1729,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1740,7 +1740,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1750,7 +1750,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1758,7 +1758,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1791,7 +1791,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1907,7 +1907,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.1"
+            "locked": "1.8.2"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -1927,17 +1927,17 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6"
+            "locked": "1.13.8"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -2005,7 +2005,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -2059,7 +2059,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2110,20 +2110,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -2244,7 +2244,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -2411,7 +2411,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -2422,16 +2422,16 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2439,7 +2439,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
@@ -2449,61 +2449,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2514,7 +2514,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -2524,10 +2524,10 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2545,33 +2545,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2584,14 +2584,14 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "org.springframework.boot:spring-boot-starter-websocket"
@@ -2923,7 +2923,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2932,7 +2932,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2940,7 +2940,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2948,21 +2948,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2993,7 +2993,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3052,7 +3052,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.1"
+            "locked": "1.8.2"
         },
         "commons-codec:commons-codec": {
             "locked": "1.16.1"
@@ -3065,17 +3065,17 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6"
+            "locked": "1.13.8"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -3083,14 +3083,14 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -3214,13 +3214,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3229,17 +3229,17 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework:spring-context-support"
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -3250,19 +3250,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
@@ -3276,19 +3276,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3298,7 +3298,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3308,7 +3308,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3318,28 +3318,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3467,7 +3467,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.1"
+            "locked": "1.8.2"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -3479,17 +3479,17 @@
             "locked": "1.16.1"
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6"
+            "locked": "1.13.8"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -3555,7 +3555,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3622,20 +3622,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3796,7 +3796,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -3807,16 +3807,16 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3824,7 +3824,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -3832,51 +3832,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3886,7 +3886,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-context-support",
@@ -3894,10 +3894,10 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3913,27 +3913,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3941,7 +3941,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -3961,19 +3961,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3983,7 +3983,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3993,7 +3993,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4003,28 +4003,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4152,7 +4152,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.1"
+            "locked": "1.8.2"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -4164,17 +4164,17 @@
             "locked": "1.16.1"
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6"
+            "locked": "1.13.8"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -4210,7 +4210,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -4275,20 +4275,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -4437,7 +4437,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -4448,16 +4448,16 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4465,7 +4465,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -4473,51 +4473,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4527,7 +4527,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-context-support",
@@ -4535,10 +4535,10 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4554,27 +4554,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -4582,7 +4582,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -4602,13 +4602,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -4621,7 +4621,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4632,7 +4632,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -4642,7 +4642,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4654,7 +4654,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4662,7 +4662,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4673,7 +4673,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4683,7 +4683,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4691,7 +4691,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4724,7 +4724,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -4840,7 +4840,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.1"
+            "locked": "1.8.2"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -4860,17 +4860,17 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6"
+            "locked": "1.13.8"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -4938,7 +4938,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4992,7 +4992,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -5031,20 +5031,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -5165,7 +5165,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -5303,7 +5303,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -5314,16 +5314,16 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -5331,7 +5331,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
@@ -5341,61 +5341,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5406,7 +5406,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -5416,10 +5416,10 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -5437,33 +5437,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -5476,14 +5476,14 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "org.springframework.boot:spring-boot-starter-websocket"

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -1061,7 +1061,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1155,7 +1155,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2159,7 +2159,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2222,7 +2222,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3735,7 +3735,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3829,7 +3829,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -93,13 +93,13 @@
     },
     "compileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -181,17 +181,17 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6"
+            "locked": "1.13.8"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -199,7 +199,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -274,35 +274,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -310,13 +310,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -329,22 +329,22 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
@@ -364,23 +364,23 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6"
+            "locked": "1.13.8"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11"
+            "locked": "3.6.12"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0"
@@ -398,30 +398,30 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-test"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "implementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -494,13 +494,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -560,35 +560,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -596,13 +596,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -614,19 +614,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
@@ -690,13 +690,13 @@
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -778,17 +778,17 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6"
+            "locked": "1.13.8"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -796,7 +796,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -917,35 +917,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -953,13 +953,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -972,22 +972,22 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
@@ -1049,13 +1049,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1068,7 +1068,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1077,7 +1077,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1087,7 +1087,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1098,14 +1098,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1113,7 +1113,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1121,14 +1121,14 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1161,7 +1161,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1243,13 +1243,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1316,7 +1316,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -1363,7 +1363,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1411,20 +1411,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1693,7 +1693,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1702,14 +1702,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -1717,51 +1717,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1770,7 +1770,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1778,7 +1778,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1793,27 +1793,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
@@ -1823,7 +1823,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -2147,13 +2147,13 @@
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2166,7 +2166,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2175,7 +2175,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2183,7 +2183,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2191,14 +2191,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2206,7 +2206,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2228,7 +2228,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2303,20 +2303,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -2329,7 +2329,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2462,35 +2462,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2498,14 +2498,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2517,19 +2517,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
@@ -2545,19 +2545,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2565,7 +2565,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2575,7 +2575,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2585,28 +2585,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2700,13 +2700,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2771,7 +2771,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2840,20 +2840,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3009,7 +3009,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3018,14 +3018,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -3033,51 +3033,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3086,14 +3086,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3108,27 +3108,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3136,7 +3136,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -3156,19 +3156,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3176,7 +3176,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3186,7 +3186,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3196,28 +3196,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3311,13 +3311,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3352,7 +3352,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3419,20 +3419,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3576,7 +3576,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3585,14 +3585,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -3600,51 +3600,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3653,14 +3653,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3675,27 +3675,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3703,7 +3703,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -3723,13 +3723,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3742,7 +3742,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3751,7 +3751,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3761,7 +3761,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3772,14 +3772,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3787,7 +3787,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3795,14 +3795,14 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3835,7 +3835,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3917,13 +3917,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3990,7 +3990,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -4037,7 +4037,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -4073,20 +4073,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -4326,7 +4326,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4335,14 +4335,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -4350,51 +4350,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4403,7 +4403,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -4411,7 +4411,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4426,27 +4426,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
@@ -4456,7 +4456,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -1,15 +1,15 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -17,7 +17,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
@@ -119,7 +119,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -154,19 +154,19 @@
     },
     "compileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -176,7 +176,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -186,7 +186,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -196,28 +196,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -324,20 +324,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -365,20 +365,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -425,61 +425,61 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -489,7 +489,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc",
@@ -497,7 +497,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -512,26 +512,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -540,13 +540,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
@@ -560,19 +560,19 @@
     },
     "implementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -582,7 +582,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -592,7 +592,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -602,28 +602,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -730,20 +730,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -771,20 +771,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -825,61 +825,61 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -889,7 +889,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc",
@@ -897,7 +897,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -912,26 +912,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -940,13 +940,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
@@ -1013,19 +1013,19 @@
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1035,7 +1035,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1045,7 +1045,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1055,28 +1055,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1183,20 +1183,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1236,20 +1236,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1330,61 +1330,61 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1394,7 +1394,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc",
@@ -1402,7 +1402,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1417,26 +1417,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -1445,13 +1445,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
@@ -1516,13 +1516,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1535,7 +1535,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1546,7 +1546,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1556,7 +1556,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1567,7 +1567,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1575,7 +1575,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1585,7 +1585,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1595,7 +1595,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1603,7 +1603,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1627,7 +1627,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1746,13 +1746,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1819,7 +1819,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1873,7 +1873,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1924,20 +1924,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -2045,7 +2045,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -2205,7 +2205,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2214,14 +2214,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
@@ -2231,57 +2231,57 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2291,7 +2291,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -2300,7 +2300,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2317,33 +2317,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2356,14 +2356,14 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "org.springframework.boot:spring-boot-starter-websocket"
@@ -2688,13 +2688,13 @@
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2707,7 +2707,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2718,7 +2718,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2728,7 +2728,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2739,7 +2739,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2747,7 +2747,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2757,7 +2757,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2767,7 +2767,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2775,7 +2775,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2799,7 +2799,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2911,20 +2911,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -2945,7 +2945,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2983,20 +2983,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3065,7 +3065,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -3105,20 +3105,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
@@ -3127,41 +3127,41 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3171,7 +3171,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -3180,7 +3180,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3195,26 +3195,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3227,14 +3227,14 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "org.springframework.boot:spring-boot-starter-websocket"
@@ -3250,19 +3250,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3272,7 +3272,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3282,7 +3282,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3292,28 +3292,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3427,13 +3427,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3498,7 +3498,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3565,20 +3565,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3732,7 +3732,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3741,14 +3741,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -3756,57 +3756,57 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3816,7 +3816,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc",
@@ -3824,7 +3824,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3841,33 +3841,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3876,13 +3876,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
@@ -3902,19 +3902,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3924,7 +3924,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3934,7 +3934,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3944,28 +3944,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4079,13 +4079,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -4120,7 +4120,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -4185,20 +4185,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -4340,7 +4340,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4349,14 +4349,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -4364,57 +4364,57 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4424,7 +4424,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc",
@@ -4432,7 +4432,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4449,33 +4449,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -4484,13 +4484,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
@@ -4510,13 +4510,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -4529,7 +4529,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4540,7 +4540,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -4550,7 +4550,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4561,7 +4561,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4569,7 +4569,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4579,7 +4579,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4589,7 +4589,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4597,7 +4597,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4621,7 +4621,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -4740,13 +4740,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -4813,7 +4813,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4867,7 +4867,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -4906,20 +4906,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -5027,7 +5027,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -5158,7 +5158,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -5167,14 +5167,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
@@ -5184,57 +5184,57 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5244,7 +5244,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -5253,7 +5253,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -5270,33 +5270,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -5309,14 +5309,14 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "org.springframework.boot:spring-boot-starter-websocket"

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -1528,7 +1528,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1621,7 +1621,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2700,7 +2700,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2793,7 +2793,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -4522,7 +4522,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -4615,7 +4615,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-spring-graphql-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-spring-graphql-example-java-webflux/dependencies.lock
@@ -2123,7 +2123,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2232,7 +2232,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3629,7 +3629,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3738,7 +3738,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -6280,7 +6280,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -6389,7 +6389,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-spring-graphql-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-spring-graphql-example-java-webflux/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -17,19 +17,19 @@
     },
     "compileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -39,7 +39,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -49,7 +49,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -59,28 +59,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -184,7 +184,8 @@
         "com.netflix.graphql.dgs:graphql-dgs-reactive": {
             "project": true,
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform"
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
@@ -237,7 +238,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -245,19 +246,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -267,7 +268,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -284,7 +285,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -296,13 +297,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -310,19 +311,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -342,7 +343,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -351,13 +352,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -365,7 +366,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -373,20 +374,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -402,20 +403,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -424,19 +425,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -522,7 +523,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -531,26 +532,26 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -559,36 +560,36 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.3.3",
@@ -597,13 +598,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -612,14 +613,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -632,19 +633,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -652,7 +653,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -666,19 +667,19 @@
     },
     "implementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -688,7 +689,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -698,7 +699,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -708,28 +709,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -833,7 +834,8 @@
         "com.netflix.graphql.dgs:graphql-dgs-reactive": {
             "project": true,
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform"
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
@@ -886,7 +888,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -894,19 +896,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -916,7 +918,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -933,7 +935,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -945,13 +947,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -959,19 +961,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -991,7 +993,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -1000,13 +1002,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -1014,7 +1016,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -1022,20 +1024,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -1051,20 +1053,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -1073,19 +1075,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1165,7 +1167,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -1174,26 +1176,26 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -1202,36 +1204,36 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.3.3",
@@ -1240,13 +1242,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1255,14 +1257,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1275,19 +1277,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -1295,7 +1297,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -1362,19 +1364,19 @@
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1384,7 +1386,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1394,7 +1396,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1404,28 +1406,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1529,7 +1531,8 @@
         "com.netflix.graphql.dgs:graphql-dgs-reactive": {
             "project": true,
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform"
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
@@ -1582,7 +1585,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -1590,19 +1593,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -1612,7 +1615,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -1629,7 +1632,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -1641,13 +1644,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1655,19 +1658,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -1687,7 +1690,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -1696,13 +1699,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -1710,7 +1713,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -1718,20 +1721,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -1747,20 +1750,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -1769,19 +1772,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1913,7 +1916,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -1922,26 +1925,26 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -1950,36 +1953,36 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.3.3",
@@ -1988,13 +1991,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2003,14 +2006,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2023,19 +2026,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -2043,7 +2046,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -2108,13 +2111,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2127,7 +2130,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2138,7 +2141,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2148,7 +2151,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2161,7 +2164,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2169,7 +2172,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2180,7 +2183,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2191,7 +2194,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2199,7 +2202,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2235,7 +2238,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2349,7 +2352,8 @@
             "project": true,
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
@@ -2403,7 +2407,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.1",
+            "locked": "1.8.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -2431,7 +2435,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -2439,20 +2443,20 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -2522,7 +2526,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2539,7 +2543,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -2551,13 +2555,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2565,19 +2569,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -2597,7 +2601,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -2606,13 +2610,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -2620,7 +2624,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -2628,20 +2632,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2657,20 +2661,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -2685,19 +2689,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -2712,7 +2716,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2760,7 +2764,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2932,7 +2936,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -3099,7 +3103,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -3110,19 +3114,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -3133,7 +3137,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-actuator",
@@ -3144,49 +3148,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3199,13 +3203,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3215,7 +3219,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -3226,13 +3230,13 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3249,26 +3253,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3283,13 +3287,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -3613,13 +3617,13 @@
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3632,7 +3636,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3643,7 +3647,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3653,7 +3657,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3666,7 +3670,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3674,7 +3678,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3685,7 +3689,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3696,7 +3700,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3704,7 +3708,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3740,7 +3744,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3853,7 +3857,8 @@
             "project": true,
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
@@ -3907,7 +3912,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.1",
+            "locked": "1.8.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -3929,7 +3934,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -3937,20 +3942,20 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -3960,7 +3965,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -3977,7 +3982,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -3989,13 +3994,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4003,19 +4008,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -4035,7 +4040,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -4044,13 +4049,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -4058,7 +4063,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -4066,20 +4071,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4095,20 +4100,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -4123,19 +4128,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -4158,7 +4163,7 @@
             "locked": "1.4.1"
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -4278,7 +4283,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -4325,7 +4330,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -4334,19 +4339,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -4356,7 +4361,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-actuator",
@@ -4366,36 +4371,36 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.3.3",
@@ -4405,13 +4410,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4421,7 +4426,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -4432,13 +4437,13 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4453,19 +4458,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4480,13 +4485,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -4501,19 +4506,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4523,7 +4528,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -4533,7 +4538,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4543,28 +4548,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4669,7 +4674,8 @@
         "com.netflix.graphql.dgs:graphql-dgs-reactive": {
             "project": true,
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform"
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
@@ -4728,7 +4734,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -4736,19 +4742,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -4816,7 +4822,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4833,7 +4839,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -4845,13 +4851,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4859,19 +4865,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -4891,7 +4897,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -4900,13 +4906,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -4914,7 +4920,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -4922,20 +4928,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4951,20 +4957,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -4973,19 +4979,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4997,7 +5003,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -5224,7 +5230,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -5235,19 +5241,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -5255,7 +5261,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -5265,49 +5271,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -5319,13 +5325,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5334,14 +5340,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -5356,26 +5362,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -5383,7 +5389,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -5403,19 +5409,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5425,7 +5431,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -5435,7 +5441,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5445,28 +5451,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -5571,7 +5577,8 @@
         "com.netflix.graphql.dgs:graphql-dgs-reactive": {
             "project": true,
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform"
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
@@ -5630,7 +5637,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -5638,19 +5645,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -5688,7 +5695,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -5705,7 +5712,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -5717,13 +5724,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5731,19 +5738,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -5763,7 +5770,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -5772,13 +5779,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -5786,7 +5793,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -5794,20 +5801,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -5823,20 +5830,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -5845,19 +5852,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -5869,7 +5876,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -6082,7 +6089,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -6093,19 +6100,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -6113,7 +6120,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -6123,49 +6130,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -6177,13 +6184,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -6192,14 +6199,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -6214,26 +6221,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -6241,7 +6248,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -6261,13 +6268,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -6280,7 +6287,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -6291,7 +6298,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -6301,7 +6308,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -6314,7 +6321,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -6322,7 +6329,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -6333,7 +6340,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -6344,7 +6351,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -6352,7 +6359,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -6388,7 +6395,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -6502,7 +6509,8 @@
             "project": true,
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
@@ -6556,7 +6564,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.1",
+            "locked": "1.8.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -6584,7 +6592,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -6592,20 +6600,20 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -6675,7 +6683,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -6692,7 +6700,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -6704,13 +6712,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -6718,19 +6726,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -6750,7 +6758,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -6759,13 +6767,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -6773,7 +6781,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -6781,20 +6789,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -6810,20 +6818,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -6838,19 +6846,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -6865,7 +6873,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -6913,7 +6921,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -7073,7 +7081,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -7211,7 +7219,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -7222,19 +7230,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -7245,7 +7253,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-actuator",
@@ -7256,49 +7264,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -7311,13 +7319,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -7327,7 +7335,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -7338,13 +7346,13 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -7361,26 +7369,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -7395,13 +7403,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]

--- a/graphql-dgs-spring-graphql-example-java/dependencies.lock
+++ b/graphql-dgs-spring-graphql-example-java/dependencies.lock
@@ -182,7 +182,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -292,7 +292,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1790,7 +1790,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1900,7 +1900,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -4706,7 +4706,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -4816,7 +4816,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-spring-graphql-example-java/dependencies.lock
+++ b/graphql-dgs-spring-graphql-example-java/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -35,7 +35,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11"
+            "locked": "3.6.12"
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
             "locked": "1.4.1"
@@ -44,13 +44,13 @@
             "locked": "1.9.25"
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "implementationDependenciesMetadata": {
@@ -73,7 +73,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11"
+            "locked": "3.6.12"
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
             "locked": "1.4.1"
@@ -82,13 +82,13 @@
             "locked": "1.9.25"
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "jmh": {
@@ -127,7 +127,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11"
+            "locked": "3.6.12"
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
             "locked": "1.4.1"
@@ -145,13 +145,13 @@
             "locked": "1.36"
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -170,13 +170,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -189,7 +189,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -200,7 +200,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -210,7 +210,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -223,7 +223,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -231,7 +231,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -242,7 +242,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -254,7 +254,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -262,7 +262,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -298,7 +298,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -420,7 +420,8 @@
             "project": true,
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
@@ -501,7 +502,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.1",
+            "locked": "1.8.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -529,7 +530,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -537,20 +538,20 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -620,7 +621,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -637,7 +638,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -649,13 +650,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -663,19 +664,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -695,7 +696,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -704,13 +705,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -718,7 +719,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -726,20 +727,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -755,20 +756,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -783,19 +784,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -812,7 +813,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -861,7 +862,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -912,20 +913,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1056,7 +1057,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -1223,7 +1224,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -1234,19 +1235,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -1259,7 +1260,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-actuator",
@@ -1271,17 +1272,17 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -1289,41 +1290,41 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -1338,20 +1339,20 @@
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.2",
+            "locked": "1.3.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1362,7 +1363,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -1375,13 +1376,13 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1399,20 +1400,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -1420,7 +1421,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1439,13 +1440,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
@@ -1453,7 +1454,7 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -1777,13 +1778,13 @@
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1796,7 +1797,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1807,7 +1808,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1817,7 +1818,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1830,7 +1831,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1838,7 +1839,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1849,7 +1850,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1861,7 +1862,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1869,7 +1870,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1905,7 +1906,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2022,7 +2023,8 @@
             "project": true,
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
@@ -2090,7 +2092,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.1",
+            "locked": "1.8.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -2112,7 +2114,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -2120,20 +2122,20 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -2143,7 +2145,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2160,7 +2162,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -2172,13 +2174,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2186,19 +2188,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -2218,7 +2220,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -2227,13 +2229,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -2241,7 +2243,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -2249,20 +2251,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2278,20 +2280,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -2306,19 +2308,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -2343,7 +2345,7 @@
             "locked": "1.4.1"
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2381,20 +2383,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -2484,7 +2486,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -2531,7 +2533,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -2540,19 +2542,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -2563,7 +2565,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-actuator",
@@ -2574,17 +2576,17 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -2592,28 +2594,28 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.3.3",
@@ -2623,14 +2625,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2641,7 +2643,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -2653,13 +2655,13 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2675,20 +2677,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2707,13 +2709,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
@@ -2721,7 +2723,7 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -2736,19 +2738,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2758,7 +2760,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2768,7 +2770,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2778,28 +2780,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2861,6 +2863,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
@@ -2907,6 +2910,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
@@ -2917,6 +2921,13 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
@@ -2994,7 +3005,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -3002,19 +3013,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -3082,7 +3093,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -3099,7 +3110,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -3111,13 +3122,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3125,19 +3136,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -3157,7 +3168,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -3166,13 +3177,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -3180,7 +3191,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -3188,20 +3199,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -3217,20 +3228,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -3239,19 +3250,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3264,7 +3275,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3333,20 +3344,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3393,6 +3404,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
@@ -3514,7 +3526,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -3525,19 +3537,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3545,7 +3557,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -3556,17 +3568,17 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3574,41 +3586,41 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3621,20 +3633,20 @@
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.2",
+            "locked": "1.3.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3644,7 +3656,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -3653,7 +3665,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3669,20 +3681,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -3690,7 +3702,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3700,13 +3712,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -3726,19 +3738,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3748,7 +3760,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3758,7 +3770,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3768,28 +3780,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3851,6 +3863,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
@@ -3897,6 +3910,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
@@ -3907,6 +3921,13 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
@@ -3984,7 +4005,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -3992,19 +4013,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -4042,7 +4063,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4059,7 +4080,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -4071,13 +4092,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4085,19 +4106,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -4117,7 +4138,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -4126,13 +4147,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -4140,7 +4161,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -4148,20 +4169,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4177,20 +4198,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -4199,19 +4220,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4224,7 +4245,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -4291,20 +4312,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -4351,6 +4372,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
@@ -4460,7 +4482,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -4471,19 +4493,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4491,7 +4513,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -4502,17 +4524,17 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -4520,41 +4542,41 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -4567,20 +4589,20 @@
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.2",
+            "locked": "1.3.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4590,7 +4612,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -4599,7 +4621,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4615,20 +4637,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -4636,7 +4658,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -4646,13 +4668,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -4672,13 +4694,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -4691,7 +4713,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4702,7 +4724,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -4712,7 +4734,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4725,7 +4747,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4733,7 +4755,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4744,7 +4766,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4756,7 +4778,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4764,7 +4786,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4800,7 +4822,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -4922,7 +4944,8 @@
             "project": true,
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
@@ -5003,7 +5026,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.1",
+            "locked": "1.8.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -5031,7 +5054,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -5039,20 +5062,20 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -5122,7 +5145,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -5139,7 +5162,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -5151,13 +5174,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5165,19 +5188,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -5197,7 +5220,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -5206,13 +5229,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -5220,7 +5243,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -5228,20 +5251,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -5257,20 +5280,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -5285,19 +5308,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -5314,7 +5337,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -5363,7 +5386,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -5402,20 +5425,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -5546,7 +5569,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -5684,7 +5707,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -5695,19 +5718,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -5720,7 +5743,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-actuator",
@@ -5732,17 +5755,17 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -5750,41 +5773,41 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -5799,20 +5822,20 @@
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.2",
+            "locked": "1.3.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5823,7 +5846,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -5836,13 +5859,13 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -5860,20 +5883,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -5881,7 +5904,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -5900,13 +5923,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
@@ -5914,7 +5937,7 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]

--- a/graphql-dgs-spring-graphql-starter-test/dependencies.lock
+++ b/graphql-dgs-spring-graphql-starter-test/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -43,19 +43,19 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -91,27 +91,27 @@
             "locked": "1.3.3"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -121,19 +121,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -175,19 +175,19 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -229,27 +229,27 @@
             "locked": "1.3.3"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -259,19 +259,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -313,19 +313,19 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -361,27 +361,27 @@
             "locked": "1.3.3"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -391,19 +391,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -498,19 +498,19 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -598,27 +598,27 @@
             "locked": "1.3.3"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -628,19 +628,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -699,13 +699,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -759,13 +759,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -831,7 +831,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -1144,7 +1144,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1153,7 +1153,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter",
@@ -1161,29 +1161,29 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -1199,20 +1199,20 @@
             "locked": "1.3.3"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -1220,7 +1220,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1233,19 +1233,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -1611,19 +1611,19 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -1675,7 +1675,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-test",
@@ -1683,20 +1683,20 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
             ]
@@ -1711,20 +1711,20 @@
             "locked": "1.3.3"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -1732,7 +1732,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -1743,19 +1743,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.graphql:spring-graphql-test"
@@ -1764,13 +1764,13 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1817,13 +1817,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -1887,7 +1887,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -2095,7 +2095,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2104,36 +2104,36 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2148,20 +2148,20 @@
             "locked": "1.3.3"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -2169,7 +2169,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2182,19 +2182,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -2216,13 +2216,13 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2269,13 +2269,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -2309,7 +2309,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -2503,7 +2503,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2512,36 +2512,36 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2556,20 +2556,20 @@
             "locked": "1.3.3"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -2577,7 +2577,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2590,19 +2590,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -2624,13 +2624,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2684,13 +2684,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -2756,7 +2756,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -3028,7 +3028,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3037,7 +3037,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter",
@@ -3045,29 +3045,29 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -3083,20 +3083,20 @@
             "locked": "1.3.3"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -3104,7 +3104,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3117,19 +3117,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",

--- a/graphql-dgs-spring-graphql-starter/dependencies.lock
+++ b/graphql-dgs-spring-graphql-starter/dependencies.lock
@@ -1,27 +1,27 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -31,7 +31,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -41,7 +41,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -51,28 +51,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -113,6 +113,7 @@
             "project": true,
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
@@ -136,11 +137,18 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
@@ -178,20 +186,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -224,6 +232,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
@@ -254,36 +263,36 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -295,13 +304,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -309,14 +318,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -328,19 +337,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
@@ -354,19 +363,19 @@
     },
     "compileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -376,7 +385,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -386,7 +395,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -396,28 +405,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -458,6 +467,7 @@
             "project": true,
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
@@ -481,11 +491,18 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
@@ -523,20 +540,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -569,6 +586,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
@@ -605,36 +623,36 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -646,13 +664,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -660,14 +678,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -679,19 +697,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
@@ -705,19 +723,19 @@
     },
     "implementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -727,7 +745,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -737,7 +755,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -747,28 +765,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -809,6 +827,7 @@
             "project": true,
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
@@ -832,11 +851,18 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
@@ -874,20 +900,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -920,6 +946,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
@@ -950,36 +977,36 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -991,13 +1018,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1005,14 +1032,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1024,19 +1051,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
@@ -1103,19 +1130,19 @@
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1125,7 +1152,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1135,7 +1162,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1145,28 +1172,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1207,6 +1234,7 @@
             "project": true,
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
@@ -1230,11 +1258,18 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
@@ -1272,20 +1307,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1330,6 +1365,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
@@ -1400,36 +1436,36 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1441,13 +1477,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1455,14 +1491,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1474,19 +1510,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
@@ -1551,13 +1587,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1570,7 +1606,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1581,7 +1617,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1591,7 +1627,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1602,7 +1638,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1610,7 +1646,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1620,7 +1656,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1631,7 +1667,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1639,7 +1675,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1663,7 +1699,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1793,13 +1829,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1872,7 +1908,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1921,7 +1957,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2076,7 +2112,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -2236,7 +2272,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2245,7 +2281,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter",
@@ -2253,7 +2289,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -2262,32 +2298,32 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2300,13 +2336,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2314,7 +2350,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -2323,7 +2359,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2338,26 +2374,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2369,7 +2405,7 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -2693,13 +2729,13 @@
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2712,7 +2748,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2723,7 +2759,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2733,7 +2769,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2744,7 +2780,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2752,7 +2788,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2762,7 +2798,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2773,7 +2809,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2781,7 +2817,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2805,7 +2841,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2928,13 +2964,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2947,7 +2983,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -2963,7 +2999,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -3066,7 +3102,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -3106,21 +3142,21 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -3128,16 +3164,16 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3150,13 +3186,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3164,7 +3200,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -3173,7 +3209,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3186,19 +3222,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3210,7 +3246,7 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -3225,19 +3261,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3247,7 +3283,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3257,7 +3293,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3267,28 +3303,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3330,6 +3366,7 @@
             "project": true,
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
@@ -3353,11 +3390,18 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
@@ -3401,13 +3445,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3472,7 +3516,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3571,6 +3615,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
@@ -3687,7 +3732,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3696,14 +3741,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -3711,32 +3756,32 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3748,13 +3793,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3762,14 +3807,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3783,26 +3828,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
@@ -3822,19 +3867,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3844,7 +3889,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3854,7 +3899,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3864,28 +3909,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3927,6 +3972,7 @@
             "project": true,
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
@@ -3950,11 +3996,18 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
@@ -3998,13 +4051,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -4039,7 +4092,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4136,6 +4189,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
@@ -4240,7 +4294,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4249,14 +4303,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -4264,32 +4318,32 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -4301,13 +4355,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4315,14 +4369,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4336,26 +4390,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
@@ -4375,13 +4429,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -4394,7 +4448,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4405,7 +4459,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -4415,7 +4469,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4426,7 +4480,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4434,7 +4488,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4444,7 +4498,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4455,7 +4509,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4463,7 +4517,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4487,7 +4541,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -4617,13 +4671,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -4696,7 +4750,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4745,7 +4799,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -4888,7 +4942,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -5019,7 +5073,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -5028,7 +5082,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter",
@@ -5036,7 +5090,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -5045,32 +5099,32 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -5083,13 +5137,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5097,7 +5151,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -5106,7 +5160,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -5121,26 +5175,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -5152,7 +5206,7 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]

--- a/graphql-dgs-spring-graphql-starter/dependencies.lock
+++ b/graphql-dgs-spring-graphql-starter/dependencies.lock
@@ -1599,7 +1599,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1693,7 +1693,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2741,7 +2741,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2835,7 +2835,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -4441,7 +4441,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -4535,7 +4535,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-spring-graphql-test/dependencies.lock
+++ b/graphql-dgs-spring-graphql-test/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -20,13 +20,13 @@
             "project": true
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -41,7 +41,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-test",
@@ -49,41 +49,41 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -94,19 +94,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-test"
             ]
@@ -117,13 +117,13 @@
             "project": true
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -132,7 +132,7 @@
             "locked": "1.9.25"
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-test",
@@ -140,41 +140,41 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -185,19 +185,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-test"
             ]
@@ -261,13 +261,13 @@
             "project": true
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -328,7 +328,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-test",
@@ -336,41 +336,41 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -381,19 +381,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-test"
             ]
@@ -452,13 +452,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -480,13 +480,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -848,7 +848,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -857,61 +857,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -924,19 +924,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
@@ -1263,13 +1263,13 @@
             "project": true
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -1284,7 +1284,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-test",
@@ -1292,41 +1292,41 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -1337,19 +1337,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-test"
             ]
@@ -1357,13 +1357,13 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1385,13 +1385,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -1646,7 +1646,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1655,61 +1655,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1722,19 +1722,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
@@ -1755,13 +1755,13 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1783,13 +1783,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -2000,7 +2000,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2009,61 +2009,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2076,19 +2076,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
@@ -2109,13 +2109,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2137,13 +2137,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -2464,7 +2464,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2473,61 +2473,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2540,19 +2540,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"

--- a/graphql-dgs-spring-graphql/dependencies.lock
+++ b/graphql-dgs-spring-graphql/dependencies.lock
@@ -1008,7 +1008,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1103,7 +1103,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2150,7 +2150,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2213,7 +2213,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3797,7 +3797,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3892,7 +3892,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-spring-graphql/dependencies.lock
+++ b/graphql-dgs-spring-graphql/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -17,7 +17,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -26,7 +26,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -34,7 +34,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -42,19 +42,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -131,20 +131,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -190,26 +190,26 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.3.3"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -219,7 +219,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -227,7 +227,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -241,51 +241,51 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webflux",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "compileOnlyDependenciesMetadata": {
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "org.springframework:spring-webflux"
             ]
@@ -300,14 +300,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -317,13 +317,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -336,38 +336,38 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webflux",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -376,7 +376,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -384,7 +384,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -392,19 +392,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -481,20 +481,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql"
@@ -530,25 +530,25 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.3.3"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -556,14 +556,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -574,19 +574,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmh": {
@@ -644,7 +644,7 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -653,7 +653,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -661,7 +661,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -669,19 +669,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -758,20 +758,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -863,26 +863,26 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.3.3"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -892,7 +892,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -900,7 +900,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -914,33 +914,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webflux",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -996,13 +996,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1015,7 +1015,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1024,7 +1024,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1034,7 +1034,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1045,14 +1045,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1060,7 +1060,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1069,14 +1069,14 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1109,7 +1109,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1211,13 +1211,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1290,7 +1290,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -1340,7 +1340,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1391,20 +1391,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1676,7 +1676,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1685,14 +1685,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -1702,42 +1702,42 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -1749,14 +1749,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1766,7 +1766,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1775,7 +1775,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1791,27 +1791,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
@@ -1823,10 +1823,10 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -2157,7 +2157,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2166,7 +2166,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2174,7 +2174,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2182,14 +2182,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2197,7 +2197,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2219,7 +2219,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2295,13 +2295,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2314,7 +2314,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -2323,7 +2323,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2430,25 +2430,25 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.3.3"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2456,7 +2456,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -2464,7 +2464,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -2475,19 +2475,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
@@ -2501,19 +2501,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2522,7 +2522,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2532,7 +2532,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2543,34 +2543,34 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2683,13 +2683,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2754,7 +2754,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -2822,20 +2822,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3000,7 +3000,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3009,14 +3009,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -3025,42 +3025,42 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3072,14 +3072,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3089,7 +3089,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -3097,7 +3097,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3113,27 +3113,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3142,10 +3142,10 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -3165,19 +3165,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3186,7 +3186,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3196,7 +3196,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3207,34 +3207,34 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3347,13 +3347,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3388,7 +3388,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -3454,20 +3454,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3620,7 +3620,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3629,14 +3629,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -3645,42 +3645,42 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3692,14 +3692,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3709,7 +3709,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -3717,7 +3717,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3733,27 +3733,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3762,10 +3762,10 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -3785,13 +3785,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3804,7 +3804,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3813,7 +3813,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3823,7 +3823,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3834,14 +3834,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3849,7 +3849,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3858,14 +3858,14 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3898,7 +3898,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -4000,13 +4000,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -4079,7 +4079,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -4129,7 +4129,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -4168,20 +4168,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -4424,7 +4424,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4433,14 +4433,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -4450,42 +4450,42 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -4497,14 +4497,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4514,7 +4514,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -4523,7 +4523,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4539,27 +4539,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
@@ -4571,10 +4571,10 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
@@ -1659,7 +1659,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1755,7 +1755,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2995,7 +2995,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3059,7 +3059,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -5192,7 +5192,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -5288,7 +5288,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
@@ -1,22 +1,22 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
@@ -114,19 +114,19 @@
     },
     "compileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -135,27 +135,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -232,20 +232,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -262,7 +262,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -274,13 +274,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -288,19 +288,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -320,7 +320,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -329,13 +329,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -343,7 +343,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -351,20 +351,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -380,20 +380,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -402,23 +402,23 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.23"
+            "locked": "1.1.24"
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -492,35 +492,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -529,13 +529,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -548,25 +548,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
@@ -577,19 +577,19 @@
     },
     "implementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -598,27 +598,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -695,20 +695,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -725,7 +725,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -737,13 +737,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -751,19 +751,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -783,7 +783,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -792,13 +792,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -806,7 +806,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -814,20 +814,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -843,20 +843,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -865,23 +865,23 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.23"
+            "locked": "1.1.24"
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -949,35 +949,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -986,13 +986,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1005,25 +1005,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
@@ -1087,19 +1087,19 @@
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -1108,27 +1108,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1205,20 +1205,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -1235,7 +1235,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -1247,13 +1247,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1261,19 +1261,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -1293,7 +1293,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -1302,13 +1302,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -1316,7 +1316,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -1324,20 +1324,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -1353,20 +1353,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -1375,23 +1375,23 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.23"
+            "locked": "1.1.24"
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -1511,35 +1511,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1548,13 +1548,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1567,25 +1567,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
@@ -1647,13 +1647,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1666,7 +1666,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1676,7 +1676,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1686,7 +1686,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1697,14 +1697,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1712,7 +1712,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1721,14 +1721,14 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1761,7 +1761,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1869,13 +1869,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1954,7 +1954,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -1972,7 +1972,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-dns",
@@ -1985,13 +1985,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1999,19 +1999,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-buffer",
@@ -2032,7 +2032,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-http",
@@ -2042,13 +2042,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -2056,7 +2056,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -2064,20 +2064,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -2094,20 +2094,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -2122,16 +2122,16 @@
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
-            "locked": "0.1.23",
+            "locked": "0.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.23"
+            "locked": "1.1.24"
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
@@ -2139,14 +2139,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -2158,7 +2158,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2203,7 +2203,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2521,7 +2521,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2530,14 +2530,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -2546,50 +2546,50 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2598,7 +2598,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -2606,7 +2606,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2622,26 +2622,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
@@ -2653,13 +2653,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -2983,13 +2983,13 @@
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3002,7 +3002,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3012,7 +3012,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3020,7 +3020,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -3028,14 +3028,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3043,7 +3043,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3065,7 +3065,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3147,13 +3147,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3172,7 +3172,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -3190,7 +3190,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-dns",
@@ -3203,13 +3203,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3217,19 +3217,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-buffer",
@@ -3250,7 +3250,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-http",
@@ -3260,13 +3260,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -3274,7 +3274,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -3282,20 +3282,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -3312,20 +3312,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -3340,16 +3340,16 @@
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
-            "locked": "0.1.23",
+            "locked": "0.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.23"
+            "locked": "1.1.24"
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
@@ -3357,13 +3357,13 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -3380,7 +3380,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -3511,35 +3511,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3548,7 +3548,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -3556,7 +3556,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3570,19 +3570,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework:spring-webflux",
@@ -3590,10 +3590,10 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -3608,19 +3608,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3630,7 +3630,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3640,7 +3640,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3651,34 +3651,34 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3792,13 +3792,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3863,7 +3863,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -3880,7 +3880,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -3892,13 +3892,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3906,19 +3906,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -3938,7 +3938,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -3947,13 +3947,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -3961,7 +3961,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -3969,20 +3969,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -3998,20 +3998,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -4020,24 +4020,24 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.23"
+            "locked": "1.1.24"
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -4047,7 +4047,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -4272,7 +4272,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4281,14 +4281,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -4296,50 +4296,50 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4348,13 +4348,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4369,26 +4369,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -4396,7 +4396,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -4416,19 +4416,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4438,7 +4438,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -4448,7 +4448,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4459,34 +4459,34 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4600,13 +4600,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -4641,7 +4641,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4658,7 +4658,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -4670,13 +4670,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4684,19 +4684,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -4716,7 +4716,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -4725,13 +4725,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -4739,7 +4739,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -4747,20 +4747,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4776,20 +4776,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -4798,24 +4798,24 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.23"
+            "locked": "1.1.24"
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -4825,7 +4825,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -5036,7 +5036,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -5045,14 +5045,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -5060,50 +5060,50 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5112,13 +5112,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -5133,26 +5133,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -5160,7 +5160,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -5180,13 +5180,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -5199,7 +5199,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5209,7 +5209,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -5219,7 +5219,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5230,14 +5230,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -5245,7 +5245,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -5254,14 +5254,14 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -5294,7 +5294,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -5402,13 +5402,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -5487,7 +5487,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -5505,7 +5505,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-dns",
@@ -5518,13 +5518,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5532,19 +5532,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-buffer",
@@ -5565,7 +5565,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-http",
@@ -5575,13 +5575,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -5589,7 +5589,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -5597,20 +5597,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -5627,20 +5627,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -5655,16 +5655,16 @@
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
-            "locked": "0.1.23",
+            "locked": "0.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.23"
+            "locked": "1.1.24"
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
@@ -5672,14 +5672,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -5691,7 +5691,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -5736,7 +5736,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -6013,7 +6013,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -6022,14 +6022,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -6038,50 +6038,50 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -6090,7 +6090,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -6098,7 +6098,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -6114,26 +6114,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
@@ -6145,13 +6145,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -1110,7 +1110,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1204,7 +1204,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2227,7 +2227,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2290,7 +2290,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3838,7 +3838,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3932,7 +3932,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -93,19 +93,19 @@
     },
     "compileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -114,7 +114,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -122,7 +122,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -130,19 +130,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -213,13 +213,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -292,36 +292,36 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -330,14 +330,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -350,26 +350,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
@@ -380,19 +380,19 @@
     },
     "implementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -401,7 +401,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -409,7 +409,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -417,19 +417,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -500,13 +500,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -573,36 +573,36 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -611,14 +611,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -631,26 +631,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
@@ -714,19 +714,19 @@
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -735,7 +735,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -743,7 +743,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -751,19 +751,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -834,13 +834,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -959,36 +959,36 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -997,14 +997,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1017,26 +1017,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
@@ -1098,13 +1098,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1117,7 +1117,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1126,7 +1126,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1136,7 +1136,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1147,14 +1147,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1162,7 +1162,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1170,14 +1170,14 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1210,7 +1210,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1302,13 +1302,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1375,7 +1375,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -1425,7 +1425,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1476,20 +1476,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1759,7 +1759,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1768,14 +1768,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -1784,51 +1784,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1837,7 +1837,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1845,7 +1845,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1860,27 +1860,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
@@ -1891,7 +1891,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -2215,13 +2215,13 @@
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2234,7 +2234,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2243,7 +2243,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2251,7 +2251,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2259,14 +2259,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2274,7 +2274,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2296,7 +2296,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2371,20 +2371,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -2400,7 +2400,7 @@
             "locked": "6.0.0"
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2530,36 +2530,36 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2568,7 +2568,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -2576,7 +2576,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2589,20 +2589,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
@@ -2610,7 +2610,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
@@ -2622,19 +2622,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2643,7 +2643,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2653,7 +2653,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2664,34 +2664,34 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2789,13 +2789,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2923,20 +2923,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3099,7 +3099,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3108,14 +3108,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -3123,51 +3123,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3176,14 +3176,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3198,27 +3198,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3226,7 +3226,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -3246,19 +3246,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3267,7 +3267,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3277,7 +3277,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3288,34 +3288,34 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3413,13 +3413,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3515,20 +3515,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3679,7 +3679,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3688,14 +3688,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -3703,51 +3703,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3756,14 +3756,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3778,27 +3778,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3806,7 +3806,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -3826,13 +3826,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3845,7 +3845,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3854,7 +3854,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3864,7 +3864,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3875,14 +3875,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3890,7 +3890,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3898,14 +3898,14 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3938,7 +3938,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -4030,13 +4030,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -4103,7 +4103,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -4153,7 +4153,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -4192,20 +4192,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -4446,7 +4446,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4455,14 +4455,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -4471,51 +4471,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4524,7 +4524,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -4532,7 +4532,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4547,27 +4547,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
@@ -4578,7 +4578,7 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -83,7 +83,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -91,27 +91,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -172,13 +172,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-web"
             ]
@@ -220,26 +220,26 @@
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-web"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-beans",
                 "org.springframework:spring-web"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "compileOnlyDependenciesMetadata": {
@@ -249,7 +249,7 @@
     },
     "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -257,27 +257,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -338,13 +338,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-web"
             ]
@@ -377,26 +377,26 @@
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-web"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-beans",
                 "org.springframework:spring-web"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmh": {
@@ -454,7 +454,7 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -462,27 +462,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -543,13 +543,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-web"
             ]
@@ -637,26 +637,26 @@
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-web"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-beans",
                 "org.springframework:spring-web"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -712,13 +712,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -731,7 +731,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -740,7 +740,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -748,7 +748,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -756,21 +756,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -792,7 +792,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -865,13 +865,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -938,7 +938,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -987,7 +987,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1287,7 +1287,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1296,49 +1296,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1347,7 +1347,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1355,7 +1355,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1370,34 +1370,34 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -1725,7 +1725,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1734,7 +1734,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1742,7 +1742,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -1750,21 +1750,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1786,7 +1786,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1852,27 +1852,27 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1977,13 +1977,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1991,13 +1991,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -2007,19 +2007,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
@@ -2033,19 +2033,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2053,27 +2053,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2141,13 +2141,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2423,7 +2423,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2432,49 +2432,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2483,14 +2483,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2505,33 +2505,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -2548,19 +2548,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2568,27 +2568,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2656,13 +2656,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2894,7 +2894,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2903,49 +2903,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2954,14 +2954,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2976,33 +2976,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -3019,13 +3019,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3038,7 +3038,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3047,7 +3047,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3055,7 +3055,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -3063,21 +3063,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3099,7 +3099,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3172,13 +3172,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3245,7 +3245,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -3294,7 +3294,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -3553,7 +3553,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3562,49 +3562,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3613,7 +3613,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -3621,7 +3621,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3636,34 +3636,34 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -724,7 +724,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -786,7 +786,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1718,7 +1718,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1780,7 +1780,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3031,7 +3031,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3093,7 +3093,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-subscription-types/dependencies.lock
+++ b/graphql-dgs-subscription-types/dependencies.lock
@@ -1,21 +1,21 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
@@ -54,13 +54,13 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
@@ -82,13 +82,13 @@
             "project": true
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -116,13 +116,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -130,13 +130,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -147,36 +147,36 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
@@ -198,13 +198,13 @@
             "project": true
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -226,13 +226,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -240,13 +240,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -257,25 +257,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmh": {
@@ -333,13 +333,13 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
@@ -361,13 +361,13 @@
             "project": true
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -441,13 +441,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -455,13 +455,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -472,25 +472,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -546,19 +546,19 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -566,27 +566,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -624,13 +624,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1001,7 +1001,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1010,48 +1010,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1059,14 +1059,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1081,32 +1081,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -1426,13 +1426,13 @@
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
@@ -1454,13 +1454,13 @@
             "project": true
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1488,13 +1488,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1502,13 +1502,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -1519,42 +1519,42 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -1562,27 +1562,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1620,13 +1620,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1896,7 +1896,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1905,48 +1905,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1954,14 +1954,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1976,32 +1976,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -2018,19 +2018,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2038,27 +2038,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2096,13 +2096,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2328,7 +2328,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2337,48 +2337,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2386,14 +2386,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2408,32 +2408,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -2450,19 +2450,19 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2470,27 +2470,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2528,13 +2528,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2864,7 +2864,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2873,48 +2873,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2922,14 +2922,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2944,32 +2944,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",

--- a/graphql-dgs-subscriptions-graphql-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-graphql-sse-autoconfigure/dependencies.lock
@@ -674,7 +674,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -738,7 +738,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1700,7 +1700,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1764,7 +1764,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2990,7 +2990,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3054,7 +3054,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-subscriptions-graphql-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-graphql-sse-autoconfigure/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -76,13 +76,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -116,23 +116,23 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -141,14 +141,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -160,26 +160,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "implementationDependenciesMetadata": {
@@ -243,13 +243,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -277,23 +277,23 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -302,14 +302,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -321,26 +321,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmh": {
@@ -457,13 +457,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -543,23 +543,23 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -568,14 +568,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -587,26 +587,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -662,13 +662,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -681,7 +681,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -691,7 +691,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -699,7 +699,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -707,14 +707,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -722,7 +722,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -744,7 +744,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -834,13 +834,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -907,7 +907,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
@@ -954,7 +954,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1256,7 +1256,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1265,49 +1265,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1316,7 +1316,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1325,7 +1325,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1341,27 +1341,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
@@ -1370,13 +1370,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -1707,7 +1707,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1717,7 +1717,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1725,7 +1725,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -1733,14 +1733,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1748,7 +1748,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1770,7 +1770,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1853,20 +1853,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
@@ -1874,7 +1874,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1981,23 +1981,23 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2006,7 +2006,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -2015,7 +2015,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -2028,20 +2028,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
@@ -2050,13 +2050,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -2070,13 +2070,13 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2148,13 +2148,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2421,7 +2421,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2430,49 +2430,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2481,14 +2481,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2503,33 +2503,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -2546,13 +2546,13 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2624,13 +2624,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2853,7 +2853,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2862,49 +2862,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2913,14 +2913,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2935,33 +2935,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -2978,13 +2978,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2997,7 +2997,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3007,7 +3007,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3015,7 +3015,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -3023,14 +3023,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3038,7 +3038,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3060,7 +3060,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3150,13 +3150,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3223,7 +3223,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
@@ -3270,7 +3270,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -3531,7 +3531,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3540,49 +3540,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3591,7 +3591,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -3600,7 +3600,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3616,27 +3616,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
@@ -3645,13 +3645,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]

--- a/graphql-dgs-subscriptions-graphql-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-graphql-sse/dependencies.lock
@@ -800,7 +800,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -863,7 +863,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1840,7 +1840,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1903,7 +1903,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3269,7 +3269,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3332,7 +3332,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-subscriptions-graphql-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-graphql-sse/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -17,7 +17,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -26,27 +26,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -115,20 +115,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -169,14 +169,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -185,13 +185,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -202,31 +202,31 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -235,27 +235,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -324,20 +324,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -372,14 +372,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -388,13 +388,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -405,26 +405,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmh": {
@@ -482,7 +482,7 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -491,27 +491,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -580,20 +580,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -680,14 +680,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -696,13 +696,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -713,26 +713,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -788,13 +788,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -807,7 +807,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -817,7 +817,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -825,7 +825,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -833,21 +833,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -869,7 +869,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -950,13 +950,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1023,7 +1023,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
@@ -1031,7 +1031,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1077,7 +1077,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1122,20 +1122,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1397,7 +1397,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1406,52 +1406,52 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1460,7 +1460,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1469,7 +1469,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1485,27 +1485,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework:spring-webmvc",
@@ -1513,10 +1513,10 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -1847,7 +1847,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1857,7 +1857,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1865,7 +1865,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -1873,21 +1873,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1909,7 +1909,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1983,27 +1983,27 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2109,14 +2109,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2125,7 +2125,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework:spring-webmvc",
@@ -2133,7 +2133,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -2145,20 +2145,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework:spring-webmvc",
@@ -2166,10 +2166,10 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -2183,19 +2183,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2204,27 +2204,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2300,13 +2300,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2371,14 +2371,14 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test"
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2444,20 +2444,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -2614,7 +2614,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2623,52 +2623,52 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2677,14 +2677,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2699,33 +2699,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -2742,19 +2742,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2763,27 +2763,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2859,13 +2859,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2900,14 +2900,14 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test"
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2971,20 +2971,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3129,7 +3129,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3138,52 +3138,52 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3192,14 +3192,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3214,33 +3214,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -3257,13 +3257,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3276,7 +3276,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3286,7 +3286,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3294,7 +3294,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -3302,21 +3302,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3338,7 +3338,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3419,13 +3419,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3492,7 +3492,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
@@ -3500,7 +3500,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3546,7 +3546,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -3579,20 +3579,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3825,7 +3825,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3834,52 +3834,52 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3888,7 +3888,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -3897,7 +3897,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3913,27 +3913,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework:spring-webmvc",
@@ -3941,10 +3941,10 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -674,7 +674,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -748,7 +748,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1710,7 +1710,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1784,7 +1784,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3010,7 +3010,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3084,7 +3084,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -76,13 +76,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -116,23 +116,23 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -141,14 +141,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -160,26 +160,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "implementationDependenciesMetadata": {
@@ -243,13 +243,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -277,23 +277,23 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -302,14 +302,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -321,26 +321,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmh": {
@@ -457,13 +457,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -543,23 +543,23 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -568,14 +568,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -587,26 +587,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -662,13 +662,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -681,7 +681,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -691,7 +691,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -700,7 +700,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -709,21 +709,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -731,7 +731,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -754,7 +754,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -844,13 +844,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -917,7 +917,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
@@ -964,7 +964,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1266,7 +1266,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1275,49 +1275,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1326,7 +1326,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1335,7 +1335,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1351,27 +1351,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
@@ -1380,13 +1380,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -1717,7 +1717,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1727,7 +1727,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1736,7 +1736,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1745,21 +1745,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1767,7 +1767,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1790,7 +1790,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1873,20 +1873,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
@@ -1894,7 +1894,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2001,23 +2001,23 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2026,7 +2026,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -2035,7 +2035,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -2048,20 +2048,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
@@ -2070,13 +2070,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -2090,13 +2090,13 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2168,13 +2168,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2441,7 +2441,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2450,49 +2450,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2501,14 +2501,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2523,33 +2523,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -2566,13 +2566,13 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2644,13 +2644,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2873,7 +2873,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2882,49 +2882,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2933,14 +2933,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2955,33 +2955,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -2998,13 +2998,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3017,7 +3017,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3027,7 +3027,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3036,7 +3036,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3045,21 +3045,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3067,7 +3067,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3090,7 +3090,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3180,13 +3180,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3253,7 +3253,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
@@ -3300,7 +3300,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -3561,7 +3561,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3570,49 +3570,49 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3621,7 +3621,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -3630,7 +3630,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3646,27 +3646,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
@@ -3675,13 +3675,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -827,7 +827,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -899,7 +899,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1876,7 +1876,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1948,7 +1948,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3332,7 +3332,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3404,7 +3404,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -17,7 +17,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -26,7 +26,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -34,7 +34,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -42,19 +42,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -124,20 +124,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -178,14 +178,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -194,13 +194,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -211,31 +211,31 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -244,7 +244,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -252,7 +252,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -260,19 +260,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -342,20 +342,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -390,14 +390,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -406,13 +406,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -423,26 +423,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmh": {
@@ -500,7 +500,7 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -509,7 +509,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -517,7 +517,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -525,19 +525,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -607,20 +607,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -707,14 +707,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -723,13 +723,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -740,26 +740,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -815,13 +815,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -834,7 +834,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -844,7 +844,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -853,7 +853,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -862,27 +862,27 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -905,7 +905,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -986,13 +986,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1059,7 +1059,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
@@ -1067,7 +1067,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1113,7 +1113,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1158,20 +1158,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1433,7 +1433,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1442,52 +1442,52 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1496,7 +1496,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1505,7 +1505,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1521,27 +1521,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework:spring-webmvc",
@@ -1549,10 +1549,10 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -1883,7 +1883,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1893,7 +1893,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1902,7 +1902,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1911,27 +1911,27 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1954,7 +1954,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2028,27 +2028,27 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2154,14 +2154,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2170,7 +2170,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework:spring-webmvc",
@@ -2178,7 +2178,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -2190,20 +2190,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework:spring-webmvc",
@@ -2211,10 +2211,10 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -2228,19 +2228,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2249,7 +2249,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2257,7 +2257,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2265,19 +2265,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2354,13 +2354,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2425,14 +2425,14 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test"
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2498,20 +2498,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -2668,7 +2668,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2677,52 +2677,52 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2731,14 +2731,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2753,33 +2753,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -2796,19 +2796,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2817,7 +2817,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2825,7 +2825,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2833,19 +2833,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2922,13 +2922,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2963,14 +2963,14 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test"
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3034,20 +3034,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3192,7 +3192,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3201,52 +3201,52 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3255,14 +3255,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3277,33 +3277,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -3320,13 +3320,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3339,7 +3339,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3349,7 +3349,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3358,7 +3358,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3367,27 +3367,27 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3410,7 +3410,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3491,13 +3491,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3564,7 +3564,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
@@ -3572,7 +3572,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3618,7 +3618,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -3651,20 +3651,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3897,7 +3897,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3906,52 +3906,52 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3960,7 +3960,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -3969,7 +3969,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3985,27 +3985,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework:spring-webmvc",
@@ -4013,10 +4013,10 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -17,7 +17,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -27,7 +27,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -35,7 +35,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -43,19 +43,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -133,13 +133,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -184,22 +184,22 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -207,14 +207,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -226,25 +226,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "compileOnlyDependenciesMetadata": {
@@ -254,7 +254,7 @@
     },
     "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -264,7 +264,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -272,7 +272,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -280,19 +280,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -370,13 +370,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -412,22 +412,22 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -435,14 +435,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -454,25 +454,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmh": {
@@ -530,7 +530,7 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -540,7 +540,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -548,7 +548,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -556,19 +556,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -646,13 +646,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -743,22 +743,22 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -766,14 +766,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -785,25 +785,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -859,13 +859,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -878,7 +878,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -888,7 +888,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -898,7 +898,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -909,14 +909,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -924,7 +924,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -932,14 +932,14 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -963,7 +963,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1053,13 +1053,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1126,7 +1126,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -1173,7 +1173,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1218,20 +1218,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1494,7 +1494,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1503,7 +1503,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "org.springframework.boot:spring-boot-starter",
@@ -1511,7 +1511,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -1519,51 +1519,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1572,7 +1572,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1581,7 +1581,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1597,27 +1597,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
@@ -1628,13 +1628,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
@@ -1966,7 +1966,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1976,7 +1976,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1984,7 +1984,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -1992,14 +1992,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2007,7 +2007,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2029,7 +2029,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2112,27 +2112,27 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2239,25 +2239,25 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2265,7 +2265,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -2273,7 +2273,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -2285,19 +2285,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
@@ -2305,7 +2305,7 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
@@ -2320,19 +2320,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2342,7 +2342,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2352,7 +2352,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2363,34 +2363,34 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2477,13 +2477,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2608,20 +2608,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -2778,7 +2778,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2787,14 +2787,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -2802,51 +2802,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2855,7 +2855,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc",
@@ -2863,7 +2863,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2879,27 +2879,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -2908,13 +2908,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -2931,19 +2931,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2953,7 +2953,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2963,7 +2963,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2974,34 +2974,34 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3088,13 +3088,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3187,20 +3187,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3345,7 +3345,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3354,14 +3354,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -3369,51 +3369,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3422,7 +3422,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc",
@@ -3430,7 +3430,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3446,27 +3446,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3475,13 +3475,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -3498,13 +3498,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3517,7 +3517,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3527,7 +3527,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3537,7 +3537,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3548,14 +3548,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3563,7 +3563,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3571,14 +3571,14 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3602,7 +3602,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3692,13 +3692,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3765,7 +3765,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -3812,7 +3812,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -3845,20 +3845,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.31",
+            "locked": "10.1.33",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -4092,7 +4092,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4101,7 +4101,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "org.springframework.boot:spring-boot-starter",
@@ -4109,7 +4109,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -4117,51 +4117,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4170,7 +4170,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -4179,7 +4179,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4195,27 +4195,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
@@ -4226,13 +4226,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -871,7 +871,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -957,7 +957,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1959,7 +1959,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2023,7 +2023,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3510,7 +3510,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3596,7 +3596,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -1,22 +1,22 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
@@ -68,7 +68,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -77,27 +77,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -166,13 +166,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
@@ -217,32 +217,32 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.3.4"
+            "locked": "6.3.5"
         },
         "org.springframework.security:spring-security-crypto": {
-            "locked": "6.3.4",
+            "locked": "6.3.5",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -251,7 +251,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.security:spring-security-core",
@@ -259,7 +259,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.security:spring-security-core",
@@ -272,37 +272,37 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "compileOnlyDependenciesMetadata": {
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
@@ -312,23 +312,23 @@
             "locked": "2.1.1"
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.3.4"
+            "locked": "6.3.5"
         },
         "org.springframework.security:spring-security-crypto": {
-            "locked": "6.3.4",
+            "locked": "6.3.5",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -336,13 +336,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -352,14 +352,14 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -367,7 +367,7 @@
     },
     "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -376,27 +376,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -465,13 +465,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -506,22 +506,22 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -529,14 +529,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -548,25 +548,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmh": {
@@ -624,7 +624,7 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -633,27 +633,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -722,13 +722,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
@@ -819,32 +819,32 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.3.4"
+            "locked": "6.3.5"
         },
         "org.springframework.security:spring-security-crypto": {
-            "locked": "6.3.4",
+            "locked": "6.3.5",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -853,7 +853,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.security:spring-security-core",
@@ -861,7 +861,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.security:spring-security-core",
@@ -874,26 +874,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -949,13 +949,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -968,7 +968,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -978,7 +978,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -986,7 +986,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -994,21 +994,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1030,7 +1030,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1111,13 +1111,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1187,7 +1187,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -1234,7 +1234,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1535,7 +1535,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1544,48 +1544,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1593,7 +1593,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1601,7 +1601,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1616,33 +1616,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -1973,7 +1973,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1983,7 +1983,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1991,7 +1991,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -1999,21 +1999,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2035,7 +2035,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2109,27 +2109,27 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2235,22 +2235,22 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2258,7 +2258,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -2266,7 +2266,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -2278,26 +2278,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -2311,19 +2311,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2332,27 +2332,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2428,13 +2428,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2502,7 +2502,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions"
@@ -2719,7 +2719,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2728,48 +2728,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2777,14 +2777,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2799,32 +2799,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -2841,19 +2841,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2862,27 +2862,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2958,13 +2958,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3002,7 +3002,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions"
@@ -3205,7 +3205,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3214,48 +3214,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3263,14 +3263,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3285,32 +3285,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -3327,13 +3327,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3346,7 +3346,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3356,7 +3356,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3364,7 +3364,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -3372,21 +3372,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3408,7 +3408,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3489,13 +3489,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3565,7 +3565,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -3612,7 +3612,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -3872,7 +3872,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3881,48 +3881,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3930,7 +3930,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -3938,7 +3938,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3953,33 +3953,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -961,7 +961,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1024,7 +1024,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1966,7 +1966,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2029,7 +2029,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3339,7 +3339,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3402,7 +3402,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-webflux-starter/dependencies.lock
+++ b/graphql-dgs-webflux-starter/dependencies.lock
@@ -2327,7 +2327,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2420,7 +2420,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3677,7 +3677,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3770,7 +3770,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -5949,7 +5949,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -6042,7 +6042,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs-webflux-starter/dependencies.lock
+++ b/graphql-dgs-webflux-starter/dependencies.lock
@@ -1,27 +1,27 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -31,7 +31,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -41,7 +41,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -51,28 +51,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -188,20 +188,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -218,7 +218,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -230,13 +230,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -244,19 +244,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -276,7 +276,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -285,13 +285,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -299,7 +299,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -307,20 +307,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -336,20 +336,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -358,19 +358,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -436,54 +436,54 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -492,13 +492,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -511,19 +511,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -531,7 +531,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -545,19 +545,19 @@
     },
     "compileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -567,7 +567,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -577,7 +577,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -587,28 +587,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -724,20 +724,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -754,7 +754,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -766,13 +766,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -780,19 +780,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -812,7 +812,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -821,13 +821,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -835,7 +835,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -843,20 +843,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -872,20 +872,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -894,19 +894,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -978,54 +978,54 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1034,13 +1034,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1053,19 +1053,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -1073,7 +1073,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -1087,19 +1087,19 @@
     },
     "implementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1109,7 +1109,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1119,7 +1119,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1129,28 +1129,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1266,20 +1266,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -1296,7 +1296,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -1308,13 +1308,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1322,19 +1322,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -1354,7 +1354,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -1363,13 +1363,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -1377,7 +1377,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -1385,20 +1385,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -1414,20 +1414,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -1436,19 +1436,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1514,54 +1514,54 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1570,13 +1570,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1589,19 +1589,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -1609,7 +1609,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -1676,19 +1676,19 @@
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1698,7 +1698,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1708,7 +1708,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1718,28 +1718,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1855,20 +1855,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -1885,7 +1885,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -1897,13 +1897,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1911,19 +1911,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -1943,7 +1943,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -1952,13 +1952,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -1966,7 +1966,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -1974,20 +1974,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2003,20 +2003,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -2025,19 +2025,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -2155,54 +2155,54 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2211,13 +2211,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2230,19 +2230,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -2250,7 +2250,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -2315,13 +2315,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2334,7 +2334,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2345,7 +2345,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2355,7 +2355,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2366,7 +2366,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2374,7 +2374,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2383,7 +2383,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2394,7 +2394,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2402,7 +2402,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2426,7 +2426,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2554,13 +2554,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2639,7 +2639,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -2657,7 +2657,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-dns",
@@ -2670,13 +2670,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2684,19 +2684,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-buffer",
@@ -2717,7 +2717,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-http",
@@ -2727,13 +2727,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -2741,7 +2741,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -2749,20 +2749,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -2779,20 +2779,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -2807,19 +2807,19 @@
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
-            "locked": "0.1.23",
+            "locked": "0.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
@@ -2827,14 +2827,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -2885,7 +2885,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -3040,7 +3040,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -3200,7 +3200,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3209,14 +3209,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
@@ -3226,50 +3226,50 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3278,7 +3278,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -3286,7 +3286,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3302,26 +3302,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3334,14 +3334,14 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -3665,13 +3665,13 @@
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3684,7 +3684,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3695,7 +3695,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3705,7 +3705,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3716,7 +3716,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3724,7 +3724,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3733,7 +3733,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3744,7 +3744,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3752,7 +3752,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3776,7 +3776,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3897,13 +3897,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3922,7 +3922,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -3940,7 +3940,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-dns",
@@ -3953,13 +3953,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3967,19 +3967,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-buffer",
@@ -4000,7 +4000,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-http",
@@ -4010,13 +4010,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -4024,7 +4024,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -4032,20 +4032,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -4062,20 +4062,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -4090,19 +4090,19 @@
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
-            "locked": "0.1.23",
+            "locked": "0.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
@@ -4110,14 +4110,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4135,7 +4135,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -4238,7 +4238,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -4278,20 +4278,20 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
@@ -4300,34 +4300,34 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4336,7 +4336,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -4344,7 +4344,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4358,19 +4358,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4383,14 +4383,14 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -4405,19 +4405,19 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4427,7 +4427,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -4437,7 +4437,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4447,28 +4447,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4591,13 +4591,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -4662,7 +4662,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4679,7 +4679,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -4691,13 +4691,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4705,19 +4705,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -4737,7 +4737,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -4746,13 +4746,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -4760,7 +4760,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -4768,20 +4768,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4797,20 +4797,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -4819,19 +4819,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -5049,7 +5049,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -5058,14 +5058,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -5073,50 +5073,50 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5125,13 +5125,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -5146,26 +5146,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -5173,7 +5173,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -5193,19 +5193,19 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5215,7 +5215,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -5225,7 +5225,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5235,28 +5235,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -5379,13 +5379,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -5420,7 +5420,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -5437,7 +5437,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -5449,13 +5449,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5463,19 +5463,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -5495,7 +5495,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -5504,13 +5504,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -5518,7 +5518,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -5526,20 +5526,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -5555,20 +5555,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -5577,19 +5577,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -5793,7 +5793,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -5802,14 +5802,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -5817,50 +5817,50 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5869,13 +5869,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -5890,26 +5890,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -5917,7 +5917,7 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -5937,13 +5937,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -5956,7 +5956,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5967,7 +5967,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -5977,7 +5977,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5988,7 +5988,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -5996,7 +5996,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -6005,7 +6005,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -6016,7 +6016,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -6024,7 +6024,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -6048,7 +6048,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -6176,13 +6176,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -6261,7 +6261,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -6279,7 +6279,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-dns",
@@ -6292,13 +6292,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -6306,19 +6306,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-buffer",
@@ -6339,7 +6339,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec-http",
@@ -6349,13 +6349,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -6363,7 +6363,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -6371,20 +6371,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-codec-classes-quic",
                 "io.netty:netty-codec",
@@ -6401,20 +6401,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.114.Final",
+            "locked": "4.1.115.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -6429,19 +6429,19 @@
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
-            "locked": "0.1.23",
+            "locked": "0.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
@@ -6449,14 +6449,14 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.1.23",
+            "locked": "1.1.24",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -6507,7 +6507,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -6650,7 +6650,7 @@
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.0",
+            "locked": "26.0.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -6781,7 +6781,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -6790,14 +6790,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
@@ -6807,50 +6807,50 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -6859,7 +6859,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -6867,7 +6867,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -6883,26 +6883,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -6915,14 +6915,14 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -70,7 +70,7 @@
     },
     "compileClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -132,7 +132,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -445,7 +445,7 @@
     },
     "implementationDependenciesMetadata": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -498,7 +498,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -743,7 +743,7 @@
     },
     "jmhCompileClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -805,7 +805,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1132,7 +1132,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1191,7 +1191,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2136,7 +2136,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2195,7 +2195,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2437,7 +2437,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2490,7 +2490,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3049,7 +3049,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3102,7 +3102,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3615,7 +3615,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.0.0",
+            "locked": "5.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3674,7 +3674,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.26.1",
+            "locked": "4.27.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -76,7 +76,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -85,7 +85,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -93,7 +93,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -101,19 +101,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -185,13 +185,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
@@ -199,7 +199,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -290,23 +290,23 @@
             ]
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.3.4"
+            "locked": "6.3.5"
         },
         "org.springframework.security:spring-security-crypto": {
-            "locked": "6.3.4",
+            "locked": "6.3.5",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -315,13 +315,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -332,20 +332,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "compileOnlyDependenciesMetadata": {
@@ -359,20 +359,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11"
+            "locked": "3.6.12"
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1"
@@ -390,23 +390,23 @@
             ]
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.3.4"
+            "locked": "6.3.5"
         },
         "org.springframework.security:spring-security-crypto": {
-            "locked": "6.3.4",
+            "locked": "6.3.5",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -414,13 +414,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -430,14 +430,14 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -451,7 +451,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -460,7 +460,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -468,7 +468,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -476,19 +476,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -551,20 +551,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -646,13 +646,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -660,10 +660,10 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -673,19 +673,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmh": {
@@ -749,7 +749,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -758,7 +758,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -766,7 +766,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -774,19 +774,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -858,13 +858,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
@@ -872,7 +872,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -1009,23 +1009,23 @@
             ]
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.3.4"
+            "locked": "6.3.5"
         },
         "org.springframework.security:spring-security-crypto": {
-            "locked": "6.3.4",
+            "locked": "6.3.5",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -1034,13 +1034,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -1051,20 +1051,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -1120,13 +1120,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1138,7 +1138,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1147,7 +1147,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1155,7 +1155,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -1163,19 +1163,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1197,7 +1197,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -1264,13 +1264,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
@@ -1338,7 +1338,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
@@ -1346,7 +1346,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1391,7 +1391,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -1704,7 +1704,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1713,58 +1713,58 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.3.4"
+            "locked": "6.3.5"
         },
         "org.springframework.security:spring-security-crypto": {
-            "locked": "6.3.4",
+            "locked": "6.3.5",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -1773,14 +1773,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1795,27 +1795,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -2142,7 +2142,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2151,7 +2151,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2159,7 +2159,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2167,19 +2167,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2201,7 +2201,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -2254,27 +2254,27 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -2375,13 +2375,13 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2389,10 +2389,10 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -2402,19 +2402,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
@@ -2425,13 +2425,13 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2443,7 +2443,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2452,7 +2452,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2460,7 +2460,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2468,19 +2468,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2556,13 +2556,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
@@ -2628,7 +2628,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
@@ -2636,7 +2636,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2909,7 +2909,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2918,58 +2918,58 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.3.4"
+            "locked": "6.3.5"
         },
         "org.springframework.security:spring-security-crypto": {
-            "locked": "6.3.4",
+            "locked": "6.3.5",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -2978,14 +2978,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3000,27 +3000,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -3037,13 +3037,13 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3055,7 +3055,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3064,7 +3064,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3072,7 +3072,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -3080,19 +3080,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3168,13 +3168,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
@@ -3210,7 +3210,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
@@ -3218,7 +3218,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3475,7 +3475,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3484,58 +3484,58 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.3.4"
+            "locked": "6.3.5"
         },
         "org.springframework.security:spring-security-crypto": {
-            "locked": "6.3.4",
+            "locked": "6.3.5",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -3544,14 +3544,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3566,27 +3566,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
@@ -3603,13 +3603,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -3621,7 +3621,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3630,7 +3630,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3638,7 +3638,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -3646,19 +3646,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3680,7 +3680,7 @@
             ]
         },
         "com.googlecode.libphonenumber:libphonenumber": {
-            "locked": "8.13.46",
+            "locked": "8.13.50",
             "transitive": [
                 "net.datafaker:datafaker"
             ]
@@ -3747,13 +3747,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
@@ -3821,7 +3821,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
@@ -3829,7 +3829,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.6.11",
+            "locked": "3.6.12",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3874,7 +3874,7 @@
             ]
         },
         "net.datafaker:datafaker": {
-            "locked": "2.4.0",
+            "locked": "2.4.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
@@ -4146,7 +4146,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4155,58 +4155,58 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.3.4"
+            "locked": "6.3.5"
         },
         "org.springframework.security:spring-security-crypto": {
-            "locked": "6.3.4",
+            "locked": "6.3.5",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -4215,14 +4215,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4237,27 +4237,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.14"
+            "locked": "6.1.15"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",

--- a/graphql-error-types/dependencies.lock
+++ b/graphql-error-types/dependencies.lock
@@ -1,10 +1,10 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         }
     },
     "apiDependenciesMetadata": {
@@ -42,13 +42,13 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
@@ -93,13 +93,13 @@
     },
     "compileOnlyDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
@@ -193,13 +193,13 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.17.2",
+            "locked": "2.17.3",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
@@ -341,13 +341,13 @@
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -382,13 +382,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -757,7 +757,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -766,61 +766,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -833,19 +833,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
@@ -1208,13 +1208,13 @@
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1249,13 +1249,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -1517,7 +1517,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1526,61 +1526,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1593,19 +1593,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
@@ -1626,13 +1626,13 @@
     },
     "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -1667,13 +1667,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -1891,7 +1891,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1900,61 +1900,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1967,19 +1967,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
@@ -2000,13 +2000,13 @@
     },
     "testRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
-            "locked": "1.5.11",
+            "locked": "1.5.12",
             "transitive": [
                 "ch.qos.logback:logback-classic"
             ]
@@ -2041,13 +2041,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.13.6",
+            "locked": "1.13.8",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -2375,7 +2375,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2384,61 +2384,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.3.5"
+            "locked": "3.3.6"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.3.5",
+            "locked": "3.3.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2451,19 +2451,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.14",
+            "locked": "6.1.15",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"


### PR DESCRIPTION

Fix for #2047

Graphql-java doesn't need a strictly version anymore, we can just use what comes from Spring Graphql. This removes issues when a new minor version of graphql-java gets released. Also updated to Boot 3.3.6