### PR TITLE
update federation-jvm to 5.3.0

### DIFF
--- a/dgs-starter-test/dependencies.lock
+++ b/dgs-starter-test/dependencies.lock
@@ -771,35 +771,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -807,25 +807,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2222,59 +2222,59 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2674,29 +2674,29 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3089,35 +3089,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3125,25 +3125,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]

--- a/dgs-starter/dependencies.lock
+++ b/dgs-starter/dependencies.lock
@@ -1479,7 +1479,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1566,7 +1566,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1681,35 +1681,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1717,25 +1717,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2952,7 +2952,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3039,7 +3039,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3580,59 +3580,59 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4156,29 +4156,29 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4530,7 +4530,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -4617,7 +4617,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -4732,35 +4732,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -4768,25 +4768,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]

--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -214,7 +214,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -301,7 +301,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -470,38 +470,38 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -509,25 +509,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2476,62 +2476,62 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3404,32 +3404,32 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4068,7 +4068,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -4155,7 +4155,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -4324,38 +4324,38 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -4363,25 +4363,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -183,7 +183,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -270,7 +270,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -454,35 +454,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -490,25 +490,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1748,7 +1748,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1804,7 +1804,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2307,59 +2307,59 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2981,29 +2981,29 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3386,7 +3386,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3473,7 +3473,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3657,35 +3657,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3693,25 +3693,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -649,7 +649,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -736,7 +736,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -877,35 +877,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -913,25 +913,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2141,7 +2141,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2197,7 +2197,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2634,59 +2634,59 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3240,29 +3240,29 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3619,7 +3619,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3706,7 +3706,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3847,35 +3847,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3883,25 +3883,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]

--- a/graphql-dgs-extended-validation/dependencies.lock
+++ b/graphql-dgs-extended-validation/dependencies.lock
@@ -825,7 +825,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -918,7 +918,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1067,35 +1067,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1103,25 +1103,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2361,7 +2361,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2423,7 +2423,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2912,59 +2912,59 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3562,29 +3562,29 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3971,7 +3971,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -4064,7 +4064,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -4213,35 +4213,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -4249,25 +4249,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -625,7 +625,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -681,7 +681,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -758,35 +758,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -794,25 +794,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1970,7 +1970,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2026,7 +2026,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2335,59 +2335,59 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2776,29 +2776,29 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3111,7 +3111,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3167,7 +3167,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3244,35 +3244,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3280,25 +3280,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]

--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
         }
         api("com.apollographql.federation:federation-graphql-java-support") {
             version {
-                require("5.2.0")
+                require("5.3.0")
             }
         }
         // ---

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -1095,7 +1095,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1151,7 +1151,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1228,35 +1228,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1264,25 +1264,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2451,7 +2451,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2507,7 +2507,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2846,59 +2846,59 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3370,29 +3370,29 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3749,7 +3749,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3805,7 +3805,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3882,35 +3882,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3918,25 +3918,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -197,7 +197,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.2"
+            "locked": "1.8.3"
         },
         "commons-codec:commons-codec": {
             "locked": "1.16.1"
@@ -744,7 +744,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.2"
+            "locked": "1.8.3"
         },
         "commons-codec:commons-codec": {
             "locked": "1.16.1"
@@ -1016,7 +1016,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.2"
+            "locked": "1.8.3"
         },
         "commons-codec:commons-codec": {
             "locked": "1.16.1"
@@ -1359,7 +1359,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1457,7 +1457,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1563,7 +1563,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.2"
+            "locked": "1.8.3"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -1602,35 +1602,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1638,25 +1638,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2947,7 +2947,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3012,7 +3012,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3062,7 +3062,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.2"
+            "locked": "1.8.3"
         },
         "commons-codec:commons-codec": {
             "locked": "1.16.1"
@@ -3451,7 +3451,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.2"
+            "locked": "1.8.3"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -3481,59 +3481,59 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4139,7 +4139,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.2"
+            "locked": "1.8.3"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -4169,29 +4169,29 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4616,7 +4616,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -4714,7 +4714,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -4820,7 +4820,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.2"
+            "locked": "1.8.3"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -4859,35 +4859,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -4895,25 +4895,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]

--- a/graphql-dgs-spring-graphql-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-spring-graphql-example-java-webflux/dependencies.lock
@@ -2048,7 +2048,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2150,7 +2150,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2295,7 +2295,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.2",
+            "locked": "1.8.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -2353,35 +2353,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -2389,25 +2389,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3889,7 +3889,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3991,7 +3991,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -4135,7 +4135,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.2",
+            "locked": "1.8.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -4943,59 +4943,59 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -5821,29 +5821,29 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -6432,7 +6432,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -6534,7 +6534,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -6679,7 +6679,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.2",
+            "locked": "1.8.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -6737,35 +6737,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -6773,25 +6773,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]

--- a/graphql-dgs-spring-graphql-example-java/dependencies.lock
+++ b/graphql-dgs-spring-graphql-example-java/dependencies.lock
@@ -2153,7 +2153,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2255,7 +2255,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2425,7 +2425,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.2",
+            "locked": "1.8.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -2483,35 +2483,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -2519,25 +2519,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4078,7 +4078,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -4180,7 +4180,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -4324,7 +4324,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.2",
+            "locked": "1.8.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -5216,59 +5216,59 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -6192,29 +6192,29 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -6861,7 +6861,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -6963,7 +6963,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -7133,7 +7133,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.2",
+            "locked": "1.8.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -7191,35 +7191,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -7227,25 +7227,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]

--- a/graphql-dgs-spring-graphql-starter-test/dependencies.lock
+++ b/graphql-dgs-spring-graphql-starter-test/dependencies.lock
@@ -827,35 +827,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -863,25 +863,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2302,59 +2302,59 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2766,29 +2766,29 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3193,35 +3193,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3229,25 +3229,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]

--- a/graphql-dgs-spring-graphql-starter/dependencies.lock
+++ b/graphql-dgs-spring-graphql-starter/dependencies.lock
@@ -1539,7 +1539,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1626,7 +1626,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1752,35 +1752,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1788,25 +1788,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3027,7 +3027,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3114,7 +3114,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3681,59 +3681,59 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4272,29 +4272,29 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4650,7 +4650,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -4737,7 +4737,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -4863,35 +4863,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -4899,25 +4899,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]

--- a/graphql-dgs-spring-graphql-test/dependencies.lock
+++ b/graphql-dgs-spring-graphql-test/dependencies.lock
@@ -492,35 +492,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -528,25 +528,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1790,59 +1790,59 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2188,29 +2188,29 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2542,35 +2542,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -2578,25 +2578,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]

--- a/graphql-dgs-spring-graphql/dependencies.lock
+++ b/graphql-dgs-spring-graphql/dependencies.lock
@@ -1038,7 +1038,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1126,7 +1126,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1238,35 +1238,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1274,25 +1274,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2551,7 +2551,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2608,7 +2608,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3060,59 +3060,59 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3732,29 +3732,29 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4179,7 +4179,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -4267,7 +4267,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -4379,35 +4379,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -4415,25 +4415,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]

--- a/graphql-dgs-subscription-types/dependencies.lock
+++ b/graphql-dgs-subscription-types/dependencies.lock
@@ -637,35 +637,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -673,25 +673,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2026,59 +2026,59 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2502,29 +2502,29 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2934,35 +2934,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -2970,25 +2970,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -61,7 +61,7 @@
     },
     "compileClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -123,7 +123,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -427,7 +427,7 @@
     },
     "implementationDependenciesMetadata": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -480,7 +480,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -716,7 +716,7 @@
     },
     "jmhCompileClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -778,7 +778,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1096,7 +1096,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1149,7 +1149,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -1222,35 +1222,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1258,25 +1258,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2464,7 +2464,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2517,7 +2517,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2731,7 +2731,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2784,7 +2784,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -2856,59 +2856,59 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3334,7 +3334,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3387,7 +3387,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -3459,29 +3459,29 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3891,7 +3891,7 @@
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "5.2.0",
+            "locked": "5.3.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3944,7 +3944,7 @@
             ]
         },
         "com.google.protobuf:protobuf-java": {
-            "locked": "4.27.1",
+            "locked": "3.25.5",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support"
             ]
@@ -4017,35 +4017,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -4053,25 +4053,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]

--- a/graphql-error-types/dependencies.lock
+++ b/graphql-error-types/dependencies.lock
@@ -394,35 +394,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -430,25 +430,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1654,59 +1654,59 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2072,29 +2072,29 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2446,35 +2446,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.13"
+            "locked": "1.13.16"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -2482,25 +2482,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.13",
+            "locked": "1.13.16",
             "transitive": [
                 "io.mockk:mockk"
             ]


### PR DESCRIPTION
`federation-jvm` v5 included a bump to a protobuf v4 version which is not ABI compatible with protobuf v3. Using protobuf v4 generates messages with a protobuf v3 service results in a runtime exception. A lot of the libraries in the `grpc` ecosystem are still stuck at v3 (including `grpc-java`) and since `federation-jvm` only uses protobuf to generate messages, the latest `federation-jvm` version ([5.3.0](https://github.com/apollographql/federation-jvm/releases/tag/v5.3.0)) also downgrades its dependency back to a v3 version (which generates messages that are compatible with both v3 and v4 versions of protobuf). 

see:
* https://github.com/apollographql/federation-jvm/issues/421
* https://github.com/grpc/grpc-java/issues/11015

