### PR TITLE
Support fallback/global type resolver

### DIFF
--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
@@ -73,6 +73,7 @@ import graphql.introspection.Introspection
 import graphql.schema.DataFetcherFactory
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.GraphQLCodeRegistry
+import graphql.schema.TypeResolver
 import graphql.schema.idl.RuntimeWiring
 import graphql.schema.idl.TypeDefinitionRegistry
 import io.micrometer.context.ContextRegistry
@@ -291,6 +292,7 @@ open class DgsSpringGraphQLAutoConfiguration(
         entityFetcherRegistry: EntityFetcherRegistry,
         defaultDataFetcherFactory: Optional<DataFetcherFactory<*>> = Optional.empty(),
         methodDataFetcherFactory: MethodDataFetcherFactory,
+        fallbackTypeResolver: TypeResolver? = null,
     ): DgsSchemaProvider =
         DgsSchemaProvider(
             applicationContext = applicationContext,
@@ -304,6 +306,7 @@ open class DgsSpringGraphQLAutoConfiguration(
             methodDataFetcherFactory = methodDataFetcherFactory,
             schemaWiringValidationEnabled = configProps.schemaWiringValidationEnabled,
             enableEntityFetcherCustomScalarParsing = configProps.enableEntityFetcherCustomScalarParsing,
+            fallbackTypeResolver = fallbackTypeResolver,
         )
 
     @Bean

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -98,7 +98,7 @@ class DgsSchemaProvider
         private val componentFilter: ((Any) -> Boolean)? = null,
         private val schemaWiringValidationEnabled: Boolean = true,
         private val enableEntityFetcherCustomScalarParsing: Boolean = false,
-        private val fallbackTypeResolver: TypeResolver? = null
+        private val fallbackTypeResolver: TypeResolver? = null,
     ) {
         @Suppress("UNUSED_PARAMETER")
         @Deprecated("The mockProviders argument is no longer supported")
@@ -827,9 +827,9 @@ class DgsSchemaProvider
                             val instance = env.getObject<Any>()
                             val resolvedType = env.schema.getObjectType(instance::class.java.simpleName)
                             resolvedType ?: fallbackTypeResolver?.getType(env)
-                            ?: throw InvalidTypeResolverException(
-                                "The default type resolver could not find a suitable Java type for GraphQL $typeName type `$it`. Provide a @DgsTypeResolver for `${instance::class.java.simpleName}`."
-                            )
+                                ?: throw InvalidTypeResolverException(
+                                    "The default type resolver could not find a suitable Java type for GraphQL $typeName type `$it`. Provide a @DgsTypeResolver for `${instance::class.java.simpleName}`.",
+                                )
                         },
                 )
             }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -46,6 +46,7 @@ import graphql.schema.FieldCoordinates
 import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLScalarType
 import graphql.schema.GraphQLSchema
+import graphql.schema.TypeResolver
 import graphql.schema.idl.RuntimeWiring
 import graphql.schema.idl.SchemaDirectiveWiring
 import graphql.schema.idl.SchemaGenerator
@@ -97,6 +98,7 @@ class DgsSchemaProvider
         private val componentFilter: ((Any) -> Boolean)? = null,
         private val schemaWiringValidationEnabled: Boolean = true,
         private val enableEntityFetcherCustomScalarParsing: Boolean = false,
+        private val fallbackTypeResolver: TypeResolver? = null
     ) {
         @Suppress("UNUSED_PARAMETER")
         @Deprecated("The mockProviders argument is no longer supported")
@@ -824,10 +826,10 @@ class DgsSchemaProvider
                         .typeResolver { env: TypeResolutionEnvironment ->
                             val instance = env.getObject<Any>()
                             val resolvedType = env.schema.getObjectType(instance::class.java.simpleName)
-                            resolvedType
-                                ?: throw InvalidTypeResolverException(
-                                    "The default type resolver could not find a suitable Java type for GraphQL $typeName type `$it`. Provide a @DgsTypeResolver for `${instance::class.java.simpleName}`.",
-                                )
+                            resolvedType ?: fallbackTypeResolver?.getType(env)
+                            ?: throw InvalidTypeResolverException(
+                                "The default type resolver could not find a suitable Java type for GraphQL $typeName type `$it`. Provide a @DgsTypeResolver for `${instance::class.java.simpleName}`."
+                            )
                         },
                 )
             }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -99,7 +99,7 @@ internal class DgsSchemaProviderTest {
             componentFilter = componentFilter,
             schemaWiringValidationEnabled = schemaWiringValidationEnabled,
             dataFetcherResultProcessors = dataFetcherResultProcessors,
-            fallbackTypeResolver = fallbackTypeResolver
+            fallbackTypeResolver = fallbackTypeResolver,
         )
 
     @DgsComponent
@@ -427,11 +427,14 @@ internal class DgsSchemaProviderTest {
             ): String? = null
         }
 
-
         contextRunner.withBean(FetcherWithDefaultResolver::class.java).withBean(VideoFetcher::class.java).run { context ->
             assertThatNoException().isThrownBy {
                 // verify that it should not trigger a build failure
-                GraphQL.newGraphQL(schemaProvider(applicationContext = context).schema(schema).graphQLSchema).build().execute("{video{title}}")
+                GraphQL
+                    .newGraphQL(
+                        schemaProvider(applicationContext = context).schema(schema).graphQLSchema,
+                    ).build()
+                    .execute("{video{title}}")
             }
         }
     }
@@ -453,15 +456,20 @@ internal class DgsSchemaProviderTest {
             """.trimIndent()
 
         class MyTypeResolverConfig {
-            fun myTypeResolver() : TypeResolver {
-                return TypeResolver { env -> env.schema.getObjectType("Show")}
-            }
+            fun myTypeResolver(): TypeResolver = TypeResolver { env -> env.schema.getObjectType("Show") }
         }
 
         contextRunner.withBean(VideoFetcher::class.java).run { context ->
             assertThatNoException().isThrownBy {
                 // verify that it should not trigger a build failure
-                GraphQL.newGraphQL(schemaProvider(applicationContext = context, fallbackTypeResolver = MyTypeResolverConfig().myTypeResolver()).schema(schema).graphQLSchema).build().execute("{video{title}}")
+                GraphQL
+                    .newGraphQL(
+                        schemaProvider(
+                            applicationContext = context,
+                            fallbackTypeResolver = MyTypeResolverConfig().myTypeResolver(),
+                        ).schema(schema).graphQLSchema,
+                    ).build()
+                    .execute("{video{title}}")
             }
         }
     }
@@ -483,9 +491,7 @@ internal class DgsSchemaProviderTest {
             """.trimIndent()
 
         class MyTypeResolverConfig {
-            fun myTypeResolver() : TypeResolver {
-                return TypeResolver { env -> env.schema.getObjectType("FakeType")}
-            }
+            fun myTypeResolver(): TypeResolver = TypeResolver { env -> env.schema.getObjectType("FakeType") }
         }
 
         @DgsComponent
@@ -500,7 +506,14 @@ internal class DgsSchemaProviderTest {
         contextRunner.withBean(FetcherWithDefaultResolver::class.java).withBean(VideoFetcher::class.java).run { context ->
             assertThatNoException().isThrownBy {
                 // verify that it should not trigger a build failure
-                GraphQL.newGraphQL(schemaProvider(applicationContext = context, fallbackTypeResolver = MyTypeResolverConfig().myTypeResolver()).schema(schema).graphQLSchema).build().execute("{video{title}}")
+                GraphQL
+                    .newGraphQL(
+                        schemaProvider(
+                            applicationContext = context,
+                            fallbackTypeResolver = MyTypeResolverConfig().myTypeResolver(),
+                        ).schema(schema).graphQLSchema,
+                    ).build()
+                    .execute("{video{title}}")
             }
         }
     }


### PR DESCRIPTION
Potential solution to https://github.com/Netflix/dgs-framework/issues/1985

Supports supplying a bean of type `TypeResolver` to act as the fallback type resolver when an explicit `@DgsTypeResolver` is not already registered for a given InterfaceType. 