### PR TITLE
Add @Source annotation to get easy access to the Source object in a @DgsData fetcher.

### DIFF
--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsInputArgumentConfiguration.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsInputArgumentConfiguration.kt
@@ -23,6 +23,7 @@ import com.netflix.graphql.dgs.internal.method.ContinuationArgumentResolver
 import com.netflix.graphql.dgs.internal.method.DataFetchingEnvironmentArgumentResolver
 import com.netflix.graphql.dgs.internal.method.FallbackEnvironmentArgumentResolver
 import com.netflix.graphql.dgs.internal.method.InputArgumentResolver
+import com.netflix.graphql.dgs.internal.method.SourceArgumentResolver
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
@@ -50,4 +51,7 @@ open class DgsInputArgumentConfiguration {
     @Bean
     @ConditionalOnMissingBean
     open fun defaultInputObjectMapper(): InputObjectMapper = DefaultInputObjectMapper()
+
+    @Bean
+    open fun sourceArgumentResolver(): ArgumentResolver = SourceArgumentResolver()
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/Source.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/Source.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface Source {
+}

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/SourceArgumentResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/SourceArgumentResolver.kt
@@ -28,7 +28,11 @@ class SourceArgumentResolver : ArgumentResolver {
         dfe: DataFetchingEnvironment,
     ): Any {
         val source = dfe.getSource<Any>()
-        if (source != null && parameter.parameterType == source.javaClass) {
+        if (source == null) {
+            throw IllegalArgumentException("Source is null. Are you trying to use @Source on a root field (e.g. @DgsQuery)?")
+        }
+
+        if (parameter.parameterType == source.javaClass) {
             return source
         } else {
             throw IllegalArgumentException(

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/SourceArgumentResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/SourceArgumentResolver.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal.method
+
+import com.netflix.graphql.dgs.Source
+import graphql.schema.DataFetchingEnvironment
+import org.springframework.core.MethodParameter
+
+class SourceArgumentResolver : ArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean = parameter.hasParameterAnnotation(Source::class.java)
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        dfe: DataFetchingEnvironment,
+    ): Any {
+        val source = dfe.getSource<Any>()
+        if (source != null && parameter.parameterType == source.javaClass) {
+            return source
+        } else {
+            throw IllegalArgumentException(
+                "Invalid source type '${source?.javaClass?.name}'. Expected type '${parameter.parameterType.name}'",
+            )
+        }
+    }
+}

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/SourceArgumentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/SourceArgumentTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal
+
+import com.netflix.graphql.dgs.DgsComponent
+import com.netflix.graphql.dgs.DgsData
+import com.netflix.graphql.dgs.DgsQuery
+import com.netflix.graphql.dgs.Source
+import com.netflix.graphql.dgs.internal.method.DataFetchingEnvironmentArgumentResolver
+import com.netflix.graphql.dgs.internal.method.FallbackEnvironmentArgumentResolver
+import com.netflix.graphql.dgs.internal.method.InputArgumentResolver
+import com.netflix.graphql.dgs.internal.method.MethodDataFetcherFactory
+import com.netflix.graphql.dgs.internal.method.SourceArgumentResolver
+import graphql.GraphQL
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.ApplicationContext
+import java.util.*
+
+internal class SourceArgumentTest {
+    private val contextRunner = ApplicationContextRunner()
+
+    private fun schemaProvider(applicationContext: ApplicationContext) =
+        DgsSchemaProvider(
+            applicationContext = applicationContext,
+            federationResolver = Optional.empty(),
+            existingTypeDefinitionRegistry = Optional.empty(),
+            schemaLocations = listOf("source-argument-test/schema.graphqls"),
+            methodDataFetcherFactory =
+                MethodDataFetcherFactory(
+                    listOf(
+                        InputArgumentResolver(DefaultInputObjectMapper()),
+                        DataFetchingEnvironmentArgumentResolver(applicationContext),
+                        SourceArgumentResolver(),
+                        FallbackEnvironmentArgumentResolver(DefaultInputObjectMapper()),
+                    ),
+                ),
+        )
+
+    data class Show(
+        val title: String,
+    )
+
+    @Test
+    fun `@Source argument`() {
+        @DgsComponent
+        class Fetcher {
+            @DgsQuery
+            fun shows(): List<Show> = listOf(Show("Stranger Things"))
+
+            @DgsData(parentType = "Show")
+            fun description(
+                @Source show: Show,
+            ): String = "Description of ${show.title}"
+        }
+
+        contextRunner.withBean(Fetcher::class.java).run { context ->
+            val provider = schemaProvider(context)
+            val schema = provider.schema().graphQLSchema
+
+            val build = GraphQL.newGraphQL(schema).build()
+            val executionResult =
+                build.execute(
+                    """{
+                |   shows {
+                |       title
+                |       description
+                |   }
+                |}
+                    """.trimMargin(),
+                )
+
+            assertThat(executionResult.errors).isEmpty()
+            assertThat(executionResult.isDataPresent).isTrue
+            val data = executionResult.getData<Map<String, *>>()
+
+            @Suppress("UNCHECKED_CAST")
+            val showData = (data["shows"] as List<Map<*, *>>)[0]
+            assertThat(showData["title"]).isEqualTo("Stranger Things")
+            assertThat(showData["description"]).isEqualTo("Description of Stranger Things")
+        }
+    }
+
+    @Test
+    fun `Incorrect @Source argument type`() {
+        @DgsComponent
+        class Fetcher {
+            @DgsQuery
+            fun shows(): List<Show> = listOf(Show("Stranger Things"))
+
+            @DgsData(parentType = "Show")
+            fun description(
+                @Source show: String,
+            ): String = "Should not be called"
+        }
+
+        contextRunner.withBean(Fetcher::class.java).run { context ->
+            val provider = schemaProvider(context)
+            val schema = provider.schema().graphQLSchema
+
+            val build = GraphQL.newGraphQL(schema).build()
+            val executionResult =
+                build.execute(
+                    """{
+                |   shows {
+                |       title
+                |       description
+                |   }
+                |}
+                    """.trimMargin(),
+                )
+
+            assertThat(executionResult.errors).isNotEmpty()
+            assertThat(
+                executionResult.errors[0].message,
+            ).contains("Invalid source type 'com.netflix.graphql.dgs.internal.SourceArgumentTest\$Show'. Expected type 'java.lang.String'")
+        }
+    }
+}

--- a/graphql-dgs/src/test/resources/source-argument-test/schema.graphqls
+++ b/graphql-dgs/src/test/resources/source-argument-test/schema.graphqls
@@ -1,0 +1,8 @@
+type Query {
+    shows: [Show]
+}
+
+type Show {
+    title: String
+    description: String
+}


### PR DESCRIPTION

Previously you would have to do: 

```java
 @DgsData(parentType = "Show")
public String artworkUrl(DgsDataFetchingEnvironment dfe) {
    Show show = dfe.getSourceOrThrow();
    // Do something with Show
}
```

```java
@DgsData(parentType = "Show")
    public String artworkUrl(@Source Show show) {
    //Do something with Show
}
```

