### PR TITLE
Update metrics for persisted query support.

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/DgsMetrics.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/DgsMetrics.kt
@@ -42,6 +42,9 @@ object DgsMetrics {
          * This is useful if you want to find data loaders that might be responsible for poor query performance.
          */
         DATA_LOADER("gql.dataLoader"),
+
+        /** _Counter_ that captures the number of GraphQL errors encountered during query execution. */
+        PERSISTED_QUERY_NOT_FOUND("gql.persistedQueryNotFound"),
     }
 
     /** Defines the tags applied to the [GqlMetric] emitted by the framework. */
@@ -91,6 +94,12 @@ object DgsMetrics {
          * Absent in case the query failed to pass GraphQL validation.
          */
         QUERY_SIG_HASH("gql.query.sig.hash"),
+
+        /** The persisted query Id in case of using automated persisted queries*/
+        PERSISTED_QUERY_ID("gql.persistedQueryId"),
+
+        /** Type of query, i.e. persisted query, full persisted query or not a persisted query.*/
+        PERSISTED_QUERY_TYPE("gql.persistedQueryType")
     }
 
     @Internal

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/DgsMetrics.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/DgsMetrics.kt
@@ -99,7 +99,7 @@ object DgsMetrics {
         PERSISTED_QUERY_ID("gql.persistedQueryId"),
 
         /** Type of query, i.e. persisted query, full persisted query or not a persisted query.*/
-        PERSISTED_QUERY_TYPE("gql.persistedQueryType")
+        PERSISTED_QUERY_TYPE("gql.persistedQueryType"),
     }
 
     @Internal

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
@@ -100,11 +100,13 @@ class DgsGraphQLMetricsInstrumentation(
         // if this is an error due to PersistedQueryNotFound, we exclude from the gql.error metric
         // this is captured in a separate counter instead
         val persistedQueryNotFoundErrors = executionResult.errors.filter { it.errorType is PersistedQueryNotFound }
-        if (persistedQueryNotFoundErrors.isNotEmpty()) { val registry = registrySupplier.get()
+        if (persistedQueryNotFoundErrors.isNotEmpty()) {
+            val registry = registrySupplier.get()
             persistedQueryNotFoundErrors.forEach {
-                val errorTags = buildList {
-                    add(Tag.of(GqlTag.PERSISTED_QUERY_ID.key, it.extensions["persistedQueryId"].toString()))
-                }
+                val errorTags =
+                    buildList {
+                        add(Tag.of(GqlTag.PERSISTED_QUERY_ID.key, it.extensions["persistedQueryId"].toString()))
+                    }
                 registry
                     .counter(GqlMetric.PERSISTED_QUERY_NOT_FOUND.key, errorTags)
                     .increment()
@@ -271,9 +273,10 @@ class DgsGraphQLMetricsInstrumentation(
     enum class PersistedQueryType {
         NOT_APQ,
         FULL_APQ,
-        APQ
+        APQ,
     }
-    private fun getPersistedQueryType(executionInput: ExecutionInput) : PersistedQueryType {
+
+    private fun getPersistedQueryType(executionInput: ExecutionInput): PersistedQueryType {
         if (executionInput.query == "PersistedQueryMarker" && executionInput.extensions.containsKey("persistedQuery")) {
             return PersistedQueryType.APQ
         } else if (executionInput.query != "PersistedQueryMarker" && executionInput.extensions.containsKey("persistedQuery")) {
@@ -351,8 +354,8 @@ class DgsGraphQLMetricsInstrumentation(
     internal object ComplexityUtils {
         private val complexityCalculator: FieldComplexityCalculator =
             FieldComplexityCalculator {
-                    _,
-                    childComplexity,
+                _,
+                childComplexity,
                 ->
                 childComplexity + 1
             }

--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
@@ -79,7 +79,9 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.Executor
 
-@SpringBootTest(properties = ["${DgsGraphQLMicrometerAutoConfiguration.AUTO_CONF_QUERY_SIG_PREFIX}.enabled=false", "dgs.graphql.apq.enabled:true"])
+@SpringBootTest(
+    properties = ["${DgsGraphQLMicrometerAutoConfiguration.AUTO_CONF_QUERY_SIG_PREFIX}.enabled=false", "dgs.graphql.apq.enabled:true"],
+)
 @EnableAutoConfiguration
 @AutoConfigureMockMvc
 @Execution(ExecutionMode.SAME_THREAD)
@@ -517,8 +519,7 @@ class MicrometerServletSmokeTest {
                     .and("gql.query.complexity", "none")
                     .and("gql.query.sig.hash", "none")
                     .and("gql.persistedQueryType", DgsGraphQLMetricsInstrumentation.PersistedQueryType.NOT_APQ.name),
-
-                )
+            )
     }
 
     @Test
@@ -737,8 +738,7 @@ class MicrometerServletSmokeTest {
                     .and("gql.query.complexity", "5")
                     .and("gql.query.sig.hash", MOCKED_QUERY_SIGNATURE.hash)
                     .and("gql.persistedQueryType", DgsGraphQLMetricsInstrumentation.PersistedQueryType.NOT_APQ.name),
-
-                )
+            )
 
         assertThat(meters["gql.resolver"]).isNotNull.hasSizeGreaterThanOrEqualTo(1)
         assertThat(meters["gql.resolver"]?.first()?.id?.tags)
@@ -860,23 +860,22 @@ class MicrometerServletSmokeTest {
         @Bean
         open fun querySignatureRepository(): QuerySignatureRepository =
             QuerySignatureRepository {
-                    _,
-                    _,
+                _,
+                _,
                 ->
                 Optional.of(MOCKED_QUERY_SIGNATURE)
             }
 
         @Bean
-        open fun contextualTagProvider(): DgsContextualTagCustomizer =
-            DgsContextualTagCustomizer { Tags.of("contextual-tag", "foo") }
+        open fun contextualTagProvider(): DgsContextualTagCustomizer = DgsContextualTagCustomizer { Tags.of("contextual-tag", "foo") }
 
         @Bean
         open fun executionTagCustomizer(): DgsExecutionTagCustomizer =
             DgsExecutionTagCustomizer {
-                    _,
-                    _,
-                    _,
-                    _,
+                _,
+                _,
+                _,
+                _,
                 ->
                 Tags.of("execution-tag", "foo")
             }
@@ -884,9 +883,9 @@ class MicrometerServletSmokeTest {
         @Bean
         open fun fieldFetchTagCustomizer(): DgsFieldFetchTagCustomizer =
             DgsFieldFetchTagCustomizer {
-                    _,
-                    _,
-                    _,
+                _,
+                _,
+                _,
                 ->
                 Tags.of("field-fetch-tag", "foo")
             }
@@ -1004,8 +1003,7 @@ class MicrometerServletSmokeTest {
         }
 
         @Bean
-        open fun customDataFetchingExceptionHandler(): DataFetcherExceptionHandler =
-            CustomDataFetchingExceptionHandler()
+        open fun customDataFetchingExceptionHandler(): DataFetcherExceptionHandler = CustomDataFetchingExceptionHandler()
 
         @Bean
         open fun dataLoaderTaskExecutor(): Executor {


### PR DESCRIPTION

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe):

Changes in this PR
----
This PR enhances our DGS metrics to track persisted query related information.
1) Automated Persisted queries (APQ) usually involve a handshake where the client sends a hash of the query first, and on failure(due to PersistedQueryNotFound), sends a full query with the hash. Subsequent queries will then be successful. Since the first attempt will result in an error, we exclude this from the `gql.error` metric to avoid falsely alerting on a spike in errors.
2) Introduced a new metric `gql.persistedQueryNotFound` to capture persistedQueryNotFound errors with a tag indicating the PQ id.
3) Enhanced `gql.query` metric  with a tag to indicate the query type - i.e. APQ, FULL_APQ, NOT_APQ. `APQ` is used when the query contains just a hash. `FULL_APQ` indicates the query has both a query and a hash (as part of the APQ handshake) and all other queries are just in the `NOT_APQ` category.



