### PR TITLE
Look for errors in the graphql response for metric tagging

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
@@ -10,9 +10,11 @@ import com.netflix.graphql.types.errors.ErrorType
 import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.GraphQLError
+import graphql.GraphQLException
 import graphql.InvalidSyntaxError
 import graphql.analysis.FieldComplexityCalculator
 import graphql.analysis.QueryComplexityCalculator
+import graphql.execution.DataFetcherResult
 import graphql.execution.ExecutionContext
 import graphql.execution.instrumentation.InstrumentationContext
 import graphql.execution.instrumentation.InstrumentationState
@@ -154,18 +156,18 @@ class DgsGraphQLMetricsInstrumentation(
             try {
                 val result = dataFetcher.get(environment)
                 if (result is CompletionStage<*>) {
-                    result.whenComplete { _, error ->
+                    result.whenComplete { value, error ->
                         recordDataFetcherMetrics(
                             registry,
                             sampler,
                             state,
                             parameters,
-                            error,
-                            baseTags,
+                            checkResponseForErrors(value, error),
+                            baseTags
                         )
                     }
                 } else {
-                    recordDataFetcherMetrics(registry, sampler, state, parameters, null, baseTags)
+                    recordDataFetcherMetrics(registry, sampler, state, parameters, checkResponseForErrors(result, null), baseTags)
                 }
                 result
             } catch (exc: Exception) {
@@ -174,6 +176,10 @@ class DgsGraphQLMetricsInstrumentation(
             }
         }
     }
+
+    private fun checkResponseForErrors(value: Any?, error: Throwable?): Throwable? = error
+        ?: (value as? DataFetcherResult<*>)?.takeIf { it.hasErrors() }
+            ?.let { GraphQLException("GraphQL errors in response: ${it.errors}") }
 
     /**
      * Port the implementation from MaxQueryComplexityInstrumentation in graphql-java and store the computed complexity

--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
@@ -39,6 +39,7 @@ import graphql.GraphQLError
 import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.DataFetcherExceptionHandlerParameters
 import graphql.execution.DataFetcherExceptionHandlerResult
+import graphql.execution.DataFetcherResult
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.idl.SchemaParser
 import graphql.schema.idl.TypeDefinitionRegistry
@@ -562,6 +563,106 @@ class MicrometerServletSmokeTest {
     }
 
     @Test
+    fun `Assert metrics for a successful async response with errors`() {
+        mvc
+            .perform(
+                MockMvcRequestBuilders
+                    .post("/graphql")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "query": "{triggerSuccessfulRequestWithErrorAsync}" }"""),
+            ).andExpect(status().isOk)
+            .andExpect(
+                content().json(
+                    """
+                        |{
+                        |   "errors":[
+                        |      {"message":"Exception triggered."}
+                        |   ],
+                        |   "data":{"triggerSuccessfulRequestWithErrorAsync":"Some data..."}
+                        |}
+                    """.trimMargin(),
+                    false,
+                ),
+            )
+
+        val meters = fetchMeters("gql.")
+
+        assertThat(meters).containsOnlyKeys("gql.error", "gql.query", "gql.resolver")
+
+        assertThat(meters["gql.error"]).isNotNull.hasSizeGreaterThanOrEqualTo(1)
+        assertThat((meters["gql.error"]?.first() as CumulativeCounter).count()).isEqualTo(1.0)
+        assertThat(meters["gql.error"]?.first()?.id?.tags)
+            .containsAll(
+                Tags
+                    .of("outcome", "failure")
+            )
+
+        assertThat(meters["gql.query"]).isNotNull.hasSizeGreaterThanOrEqualTo(1)
+        assertThat(meters["gql.query"]?.first()?.id?.tags)
+            .containsAll(
+                Tags
+                    .of("outcome", "failure")
+            )
+
+        assertThat(meters["gql.resolver"]).isNotNull.hasSizeGreaterThanOrEqualTo(1)
+        assertThat(meters["gql.resolver"]?.first()?.id?.tags)
+            .containsAll(
+                Tags
+                    .of("outcome", "failure")
+            )
+    }
+
+    @Test
+    fun `Assert metrics for a successful sync response with errors`() {
+        mvc
+            .perform(
+                MockMvcRequestBuilders
+                    .post("/graphql")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{ "query": "{triggerSuccessfulRequestWithErrorSync}" }"""),
+            ).andExpect(status().isOk)
+            .andExpect(
+                content().json(
+                    """
+                        |{
+                        |   "errors":[
+                        |      {"message":"Exception triggered."}
+                        |   ],
+                        |   "data":{"triggerSuccessfulRequestWithErrorSync":"Some data..."}
+                        |}
+                    """.trimMargin(),
+                    false,
+                ),
+            )
+
+        val meters = fetchMeters("gql.")
+
+        assertThat(meters).containsOnlyKeys("gql.error", "gql.query", "gql.resolver")
+
+        assertThat(meters["gql.error"]).isNotNull.hasSizeGreaterThanOrEqualTo(1)
+        assertThat((meters["gql.error"]?.first() as CumulativeCounter).count()).isEqualTo(1.0)
+        assertThat(meters["gql.error"]?.first()?.id?.tags)
+            .containsAll(
+                Tags
+                    .of("outcome", "failure")
+            )
+
+        assertThat(meters["gql.query"]).isNotNull.hasSizeGreaterThanOrEqualTo(1)
+        assertThat(meters["gql.query"]?.first()?.id?.tags)
+            .containsAll(
+                Tags
+                    .of("outcome", "failure")
+            )
+
+        assertThat(meters["gql.resolver"]).isNotNull.hasSizeGreaterThanOrEqualTo(1)
+        assertThat(meters["gql.resolver"]?.first()?.id?.tags)
+            .containsAll(
+                Tags
+                    .of("outcome", "failure")
+            )
+    }
+
+    @Test
     fun `Assert metrics for custom error`() {
         mvc
             .perform(
@@ -793,6 +894,8 @@ class MicrometerServletSmokeTest {
                 |    triggerInternalFailure: String
                 |    triggerBadRequestFailure:String
                 |    triggerCustomFailure: String
+                |    triggerSuccessfulRequestWithErrorAsync:String
+                |    triggerSuccessfulRequestWithErrorSync:String
                 |}
                 |
                 |type Mutation{
@@ -834,6 +937,18 @@ class MicrometerServletSmokeTest {
 
             @DgsQuery
             fun triggerBadRequestFailure(): String = throw DgsBadRequestException("Exception triggered.")
+
+            @DgsQuery
+            fun triggerSuccessfulRequestWithErrorAsync(): CompletableFuture<DataFetcherResult<String>> = CompletableFuture.supplyAsync { DataFetcherResult.newResult<String>()
+                .data("Some data...")
+                .error(TypedGraphQLError("Exception triggered.", null, null, null, null))
+                .build()}
+
+            @DgsQuery
+            fun triggerSuccessfulRequestWithErrorSync(): DataFetcherResult<String> = DataFetcherResult.newResult<String>()
+                .data("Some data...")
+                .error(TypedGraphQLError("Exception triggered.", null, null, null, null))
+                .build()
 
             @DgsQuery
             fun triggerCustomFailure(): String = throw CustomException("Exception triggered.")


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
It's possible to manually craft a `DataFetcherResult` and place errors within the error field. In the previous implementation, if your datafetcher were to catch all it's own exceptions and do this manual creation of a `DataFetcherResult`, these requests would not properly get tagged as a request which contained an error in metrics.

This changes the implementation to inspect the actual graphql response/result to check if it contains errors on top of just looking for exceptions.
