### PR TITLE
OSS Upgrade to spring-boot 3.5 and spring-graphql 1.4.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
     // and suggest an upgrade. The only exception currently are those defined
     // in buildSrc, most likely because the variables are used in plugins as well
     // as dependencies. e.g. KOTLIN_VERSION
-    extra["sb.version"] = "3.4.5"
+    extra["sb.version"] = "3.5.0"
     extra["kotlin.version"] = Versions.KOTLIN_VERSION
 }
 val internalBomModules by extra(
@@ -96,9 +96,14 @@ configure(subprojects.filterNot { it in internalBomModules }) {
             exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
         }
 
-
+        implementation("org.slf4j:slf4j-api:2.0.17")
         implementation("org.jetbrains:annotations:26.0.2")
         testImplementation("io.mockk:mockk:1.+")
+
+        // JUnit 5 dependencies
+        testImplementation(platform("org.junit:junit-bom:5.12.2"))
+        testImplementation("org.junit.jupiter:junit-jupiter")
+        testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     }
 
     jmh {

--- a/dgs-starter-test/dependencies.lock
+++ b/dgs-starter-test/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -9,7 +9,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -35,19 +35,19 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -60,50 +60,52 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
-        },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5"
+            "locked": "1.4.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -113,19 +115,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -133,7 +135,7 @@
     },
     "compileClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -141,7 +143,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -167,19 +169,19 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -198,50 +200,55 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
+            "locked": "2.0.17"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5"
+            "locked": "1.4.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -251,19 +258,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -271,7 +278,7 @@
     },
     "implementationDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -279,7 +286,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -305,19 +312,19 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -333,50 +340,55 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
+            "locked": "2.0.17"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5"
+            "locked": "1.4.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -386,19 +398,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -459,7 +471,7 @@
     },
     "jmhCompileClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -467,7 +479,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -493,19 +505,19 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -534,6 +546,13 @@
             "locked": "26.0.2",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.openjdk.jmh:jmh-core": {
@@ -574,46 +593,44 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
+            "locked": "2.0.17"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5"
+            "locked": "1.4.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -623,19 +640,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -706,7 +723,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -714,7 +731,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -754,47 +771,47 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -802,31 +819,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -858,7 +875,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -866,7 +883,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -912,19 +929,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -932,7 +949,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -990,8 +1007,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -999,7 +1023,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -1009,21 +1033,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -1031,32 +1055,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -1114,6 +1146,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -1133,14 +1166,14 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1149,7 +1182,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter",
@@ -1157,58 +1190,58 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5"
+            "locked": "1.4.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -1216,7 +1249,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1229,19 +1262,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -1249,13 +1282,13 @@
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1771,7 +1804,7 @@
     },
     "runtimeClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -1779,7 +1812,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1812,19 +1845,19 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -1856,6 +1889,13 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.ow2.asm:asm": {
             "locked": "9.7.1",
             "transitive": [
@@ -1866,18 +1906,19 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "com.jayway.jsonpath:json-path"
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-test",
@@ -1885,48 +1926,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5"
+            "locked": "1.4.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -1934,7 +1975,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -1945,19 +1986,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.graphql:spring-graphql-test"
@@ -1978,7 +2019,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -1986,7 +2027,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2019,77 +2060,77 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -2115,7 +2156,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -2123,7 +2164,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -2164,19 +2205,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -2199,15 +2240,22 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -2215,21 +2263,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -2238,14 +2286,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2272,6 +2320,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -2291,13 +2340,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2306,64 +2354,64 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5"
+            "locked": "1.4.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -2371,7 +2419,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2384,19 +2432,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -2404,13 +2452,13 @@
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2430,7 +2478,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -2438,7 +2486,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2471,47 +2519,47 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -2537,14 +2585,14 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -2584,19 +2632,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -2616,15 +2664,22 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -2632,21 +2687,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -2655,14 +2710,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2683,6 +2738,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -2702,13 +2758,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2717,64 +2772,64 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5"
+            "locked": "1.4.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -2782,7 +2837,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2795,19 +2850,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -2815,13 +2870,13 @@
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2841,7 +2896,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -2849,7 +2904,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2889,47 +2944,47 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -2937,31 +2992,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -2993,7 +3048,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -3001,7 +3056,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -3035,19 +3090,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -3055,7 +3110,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -3113,8 +3168,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -3122,7 +3184,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -3132,21 +3194,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -3154,32 +3216,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3208,6 +3278,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -3227,14 +3298,14 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3243,7 +3314,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter",
@@ -3251,58 +3322,58 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5"
+            "locked": "1.4.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -3310,7 +3381,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3323,19 +3394,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -3343,13 +3414,13 @@
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/dgs-starter/dependencies.lock
+++ b/dgs-starter/dependencies.lock
@@ -13,7 +13,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -23,7 +23,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -33,7 +33,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -43,28 +43,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -75,7 +75,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -85,7 +85,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -151,20 +151,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -202,10 +202,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -219,60 +227,59 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -280,14 +287,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -299,25 +306,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -337,7 +344,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -347,7 +354,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -357,7 +364,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -367,28 +374,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -399,7 +406,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -409,7 +416,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -475,20 +482,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -532,10 +539,18 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -549,60 +564,59 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -610,14 +624,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -629,25 +643,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -667,7 +681,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -677,7 +691,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -687,7 +701,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -697,28 +711,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -729,7 +743,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -739,7 +753,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -805,20 +819,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -859,10 +873,18 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -876,60 +898,59 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -937,14 +958,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -956,25 +977,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1047,7 +1068,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1057,7 +1078,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1067,7 +1088,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1077,28 +1098,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1109,7 +1130,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1119,7 +1140,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1185,20 +1206,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1254,6 +1275,13 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37",
             "transitive": [
@@ -1292,6 +1320,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -1305,60 +1334,59 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1366,14 +1394,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1385,25 +1413,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1481,7 +1509,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1492,7 +1520,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1502,7 +1530,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1513,7 +1541,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1521,7 +1549,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1531,7 +1559,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1541,7 +1569,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1549,7 +1577,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1567,7 +1595,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1579,7 +1607,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1663,48 +1691,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1712,25 +1740,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1742,7 +1770,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1776,7 +1804,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -1784,7 +1812,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -1830,19 +1858,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -1850,7 +1878,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -1942,8 +1970,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -1951,7 +1986,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -1961,21 +1996,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -1983,32 +2018,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2066,6 +2109,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -2087,14 +2131,19 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2103,7 +2152,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter",
@@ -2111,7 +2160,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -2119,51 +2168,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2171,7 +2220,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -2180,7 +2229,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2195,26 +2244,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2224,19 +2273,19 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2771,7 +2820,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2782,7 +2831,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2792,7 +2841,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2803,7 +2852,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2811,7 +2860,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2821,7 +2870,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2831,7 +2880,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2839,7 +2888,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2857,7 +2906,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2869,7 +2918,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2946,13 +2995,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2965,7 +3014,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3080,6 +3129,13 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.ow2.asm:asm": {
             "locked": "9.7.1",
             "transitive": [
@@ -3090,6 +3146,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -3105,63 +3162,68 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3169,7 +3231,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -3178,7 +3240,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3191,19 +3253,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3213,13 +3275,13 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3239,7 +3301,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3249,7 +3311,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3259,7 +3321,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3269,28 +3331,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3301,7 +3363,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3311,7 +3373,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3384,78 +3446,78 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3481,7 +3543,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -3489,7 +3551,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -3530,19 +3592,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -3570,15 +3632,22 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -3586,21 +3655,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -3609,14 +3678,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3643,6 +3712,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -3662,13 +3732,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3677,14 +3746,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -3692,50 +3761,50 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3743,14 +3812,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3764,38 +3833,38 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3815,7 +3884,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3825,7 +3894,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3835,7 +3904,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3845,28 +3914,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3877,7 +3946,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3887,7 +3956,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3960,48 +4029,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4027,14 +4096,14 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -4074,19 +4143,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -4111,15 +4180,22 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -4127,21 +4203,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -4150,14 +4226,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -4178,6 +4254,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -4197,13 +4274,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4212,14 +4288,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -4227,50 +4303,50 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4278,14 +4354,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4299,38 +4375,38 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -4357,7 +4433,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4368,7 +4444,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -4378,7 +4454,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4389,7 +4465,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4397,7 +4473,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4407,7 +4483,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4417,7 +4493,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4425,7 +4501,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4443,7 +4519,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4455,7 +4531,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4539,48 +4615,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -4588,25 +4664,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4618,7 +4694,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4652,7 +4728,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -4660,7 +4736,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -4694,19 +4770,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -4714,7 +4790,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -4806,8 +4882,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -4815,7 +4898,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -4825,21 +4908,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -4847,32 +4930,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -4901,6 +4992,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -4922,14 +5014,19 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4938,7 +5035,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter",
@@ -4946,7 +5043,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -4954,51 +5051,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5006,7 +5103,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -5015,7 +5112,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -5030,26 +5127,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -5059,19 +5156,19 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "apiDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3"
+            "locked": "2.19.0"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.9.0"
@@ -13,7 +13,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5"
+            "locked": "3.7.6"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.20"
@@ -21,22 +21,22 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3"
+            "locked": "2.19.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3"
+            "locked": "2.19.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3"
+            "locked": "2.19.0"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3"
+            "locked": "2.19.0"
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3"
+            "locked": "2.19.0"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3"
+            "locked": "24.0"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.9.0"
@@ -48,7 +48,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5"
+            "locked": "3.7.6"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.20"
@@ -56,36 +56,39 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework:spring-web": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "compileOnlyDependenciesMetadata": {
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3"
+            "locked": "2.19.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3"
+            "locked": "2.19.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3"
+            "locked": "2.19.0"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3"
+            "locked": "2.19.0"
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3"
+            "locked": "2.19.0"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3"
+            "locked": "24.0"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.9.0"
@@ -97,7 +100,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5"
+            "locked": "3.7.6"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.20"
@@ -105,8 +108,11 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework:spring-web": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "jmh": {
@@ -127,22 +133,22 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3"
+            "locked": "2.19.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3"
+            "locked": "2.19.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3"
+            "locked": "2.19.0"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3"
+            "locked": "2.19.0"
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3"
+            "locked": "2.19.0"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3"
+            "locked": "24.0"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.9.0"
@@ -154,7 +160,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5"
+            "locked": "3.7.6"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.20"
@@ -171,11 +177,14 @@
         "org.openjdk.jmh:jmh-generator-bytecode": {
             "locked": "1.36"
         },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework:spring-web": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -213,7 +222,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -224,7 +233,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -234,7 +243,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -245,7 +254,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -253,7 +262,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -263,7 +272,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -273,7 +282,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -281,7 +290,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -299,7 +308,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -320,7 +329,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -449,51 +458,51 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -501,31 +510,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -542,7 +551,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -554,13 +563,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -568,19 +577,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -600,7 +609,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -609,13 +618,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -623,7 +632,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -631,20 +640,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -660,20 +669,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -688,19 +697,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -715,7 +724,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -747,7 +756,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -755,7 +764,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -801,38 +810,38 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -840,7 +849,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -942,16 +951,24 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
-        "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
             "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.12.2",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -961,21 +978,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -983,32 +1000,42 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -1073,6 +1100,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -1094,14 +1122,24 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:dgs-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1110,7 +1148,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
@@ -1119,7 +1157,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -1129,13 +1167,13 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -1143,57 +1181,57 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -1201,20 +1239,20 @@
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1224,7 +1262,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1235,7 +1273,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1252,20 +1290,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -1274,7 +1312,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1288,31 +1326,31 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1828,7 +1866,7 @@
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1838,7 +1876,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1848,7 +1886,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1858,31 +1896,31 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1894,14 +1932,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1926,20 +1964,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1976,6 +2014,13 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.ow2.asm:asm": {
             "locked": "9.7.1",
             "transitive": [
@@ -1986,24 +2031,25 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "com.jayway.jsonpath:json-path"
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2011,13 +2057,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -2028,25 +2074,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
@@ -2066,7 +2112,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2077,7 +2123,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2087,7 +2133,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2098,7 +2144,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2106,7 +2152,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2114,14 +2160,14 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2129,7 +2175,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2141,7 +2187,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2160,7 +2206,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2278,81 +2324,81 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2369,7 +2415,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -2381,13 +2427,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2395,19 +2441,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -2427,7 +2473,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -2436,13 +2482,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -2450,7 +2496,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -2458,20 +2504,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2487,20 +2533,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -2509,19 +2555,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -2534,7 +2580,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2560,7 +2606,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -2568,7 +2614,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -2601,20 +2647,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -2628,19 +2674,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -2681,15 +2727,23 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
-        "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
             "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.12.2",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -2697,22 +2751,23 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -2720,14 +2775,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2754,6 +2809,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -2773,13 +2829,13 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2788,14 +2844,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -2805,13 +2861,13 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -2819,76 +2875,76 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2898,7 +2954,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -2907,7 +2963,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2923,20 +2979,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -2945,7 +3001,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -2956,25 +3012,25 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2994,7 +3050,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3005,7 +3061,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3015,7 +3071,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3026,7 +3082,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3034,7 +3090,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3042,14 +3098,14 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3057,7 +3113,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3069,7 +3125,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3088,7 +3144,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3206,51 +3262,51 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -3267,7 +3323,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -3279,13 +3335,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3293,19 +3349,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -3325,7 +3381,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -3334,13 +3390,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -3348,7 +3404,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -3356,20 +3412,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -3385,20 +3441,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -3407,19 +3463,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3432,7 +3488,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3458,14 +3514,14 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -3497,20 +3553,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3524,19 +3580,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -3576,15 +3632,23 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
-        "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
             "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.12.2",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -3592,22 +3656,23 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -3615,14 +3680,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3643,6 +3708,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -3662,13 +3728,13 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3677,14 +3743,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -3694,13 +3760,13 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3708,76 +3774,76 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3787,7 +3853,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -3796,7 +3862,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3812,20 +3878,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -3834,7 +3900,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -3845,25 +3911,25 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3890,7 +3956,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3901,7 +3967,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3911,7 +3977,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3922,7 +3988,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3930,7 +3996,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3940,7 +4006,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3950,7 +4016,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3958,7 +4024,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3976,7 +4042,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -3997,7 +4063,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4126,51 +4192,51 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -4178,31 +4244,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4219,7 +4285,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -4231,13 +4297,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4245,19 +4311,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -4277,7 +4343,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -4286,13 +4352,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -4300,7 +4366,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -4308,20 +4374,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4337,20 +4403,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -4365,19 +4431,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4392,7 +4458,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -4424,7 +4490,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -4432,7 +4498,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -4466,38 +4532,38 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -4505,7 +4571,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -4607,16 +4673,24 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
-        "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
             "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.12.2",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -4626,21 +4700,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -4648,32 +4722,42 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -4702,6 +4786,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -4723,14 +4808,24 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:dgs-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4739,7 +4834,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
@@ -4748,7 +4843,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -4758,13 +4853,13 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -4772,57 +4867,57 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -4830,20 +4925,20 @@
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4853,7 +4948,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -4864,7 +4959,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4881,20 +4976,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -4903,7 +4998,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4917,31 +5012,31 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -8,60 +8,28 @@
         }
     },
     "compileClasspath": {
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3"
-        },
-        "com.netflix.graphql.dgs:graphql-dgs-extended-scalars": {
-            "project": true
-        },
-        "com.netflix.graphql.dgs:graphql-dgs-pagination": {
-            "project": true
-        },
-        "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "project": true
-        },
-        "io.projectreactor:reactor-core": {
-            "locked": "3.7.5"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.20"
-        },
-        "org.jetbrains:annotations": {
-            "locked": "26.0.2"
-        },
-        "org.springframework:spring-context": {
-            "locked": "6.2.6"
-        },
-        "org.springframework:spring-web": {
-            "locked": "6.2.6"
-        },
-        "org.springframework:spring-webflux": {
-            "locked": "6.2.6"
-        }
-    },
-    "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -69,7 +37,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -84,7 +52,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -135,20 +103,219 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.20",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.jetbrains:annotations": {
+            "locked": "26.0.2",
+            "transitive": [
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.2.7",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.2.7",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.2.7"
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.2.7",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.2.7",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.2.7",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.2.7",
+            "transitive": [
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.2.7"
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.19.0",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.19.0",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.19.0",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.19.0",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "24.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "22.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "5.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-extended-scalars": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-pagination": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.15.0",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.15.0",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework:spring-webflux"
@@ -166,27 +333,32 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
+            "locked": "2.0.17"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -195,10 +367,10 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -209,25 +381,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "jmh": {
@@ -285,27 +457,27 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -313,7 +485,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -328,7 +500,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -379,20 +551,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework:spring-webflux"
@@ -423,6 +595,13 @@
             "locked": "26.0.2",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.openjdk.jmh:jmh-core": {
@@ -463,23 +642,21 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
+            "locked": "2.0.17"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -488,10 +665,10 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -502,25 +679,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -595,7 +772,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -606,7 +783,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -616,7 +793,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -627,7 +804,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -635,7 +812,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -645,7 +822,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -655,7 +832,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -663,7 +840,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -681,7 +858,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -703,7 +880,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -846,48 +1023,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -895,31 +1072,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -936,7 +1113,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -948,13 +1125,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -962,19 +1139,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -994,7 +1171,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -1003,13 +1180,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -1017,7 +1194,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -1025,20 +1202,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -1054,20 +1231,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -1082,19 +1259,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1109,7 +1286,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1140,10 +1317,10 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -1151,7 +1328,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -1197,38 +1374,38 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -1236,7 +1413,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -1342,8 +1519,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -1351,7 +1535,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -1361,21 +1545,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -1383,32 +1567,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -1466,6 +1658,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -1487,14 +1680,26 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:dgs-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1503,7 +1708,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -1514,7 +1719,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -1524,14 +1729,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -1539,48 +1744,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -1588,20 +1793,20 @@
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1611,7 +1816,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1622,7 +1827,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1639,20 +1844,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -1660,7 +1865,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1674,31 +1879,31 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2221,7 +2426,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2230,7 +2435,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2238,7 +2443,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2246,21 +2451,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2276,7 +2481,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -2294,7 +2499,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2352,20 +2557,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
@@ -2453,6 +2658,13 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.ow2.asm:asm": {
             "locked": "9.7.1",
             "transitive": [
@@ -2463,6 +2675,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -2471,31 +2684,34 @@
             "locked": "2.0.17",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
-                "com.jayway.jsonpath:json-path"
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2504,14 +2720,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -2523,26 +2739,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "testCompileClasspath": {
@@ -2559,7 +2775,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2569,7 +2785,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2579,7 +2795,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2589,28 +2805,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2621,7 +2837,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -2639,7 +2855,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2771,78 +2987,78 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2859,7 +3075,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -2871,13 +3087,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2885,19 +3101,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -2917,7 +3133,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -2926,13 +3142,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -2940,7 +3156,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -2948,20 +3164,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2977,20 +3193,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -2999,19 +3215,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3024,7 +3240,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3049,10 +3265,10 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -3060,7 +3276,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -3093,20 +3309,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3120,19 +3336,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -3167,15 +3383,22 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -3183,21 +3406,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -3206,14 +3429,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3240,6 +3463,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -3259,13 +3483,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3274,14 +3497,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -3291,14 +3514,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3306,67 +3529,67 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3376,7 +3599,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -3385,7 +3608,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3401,20 +3624,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -3422,7 +3645,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3432,25 +3655,25 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3470,7 +3693,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3480,7 +3703,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3490,7 +3713,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3500,28 +3723,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3532,7 +3755,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3550,7 +3773,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3682,48 +3905,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -3740,7 +3963,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -3752,13 +3975,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -3766,19 +3989,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -3798,7 +4021,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -3807,13 +4030,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -3821,7 +4044,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -3829,20 +4052,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -3858,20 +4081,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -3880,19 +4103,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3905,7 +4128,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3930,17 +4153,17 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -3972,20 +4195,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3999,19 +4222,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -4043,15 +4266,22 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -4059,21 +4289,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -4082,14 +4312,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -4110,6 +4340,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -4129,13 +4360,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4144,14 +4374,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -4161,14 +4391,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -4176,67 +4406,67 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4246,7 +4476,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -4255,7 +4485,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4271,20 +4501,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -4292,7 +4522,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -4302,25 +4532,25 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -4347,7 +4577,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4358,7 +4588,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -4368,7 +4598,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4379,7 +4609,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4387,7 +4617,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4397,7 +4627,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4407,7 +4637,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4415,7 +4645,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4433,7 +4663,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -4455,7 +4685,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4598,48 +4828,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -4647,31 +4877,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4688,7 +4918,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -4700,13 +4930,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4714,19 +4944,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -4746,7 +4976,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -4755,13 +4985,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -4769,7 +4999,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -4777,20 +5007,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4806,20 +5036,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -4834,19 +5064,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4861,7 +5091,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -4892,10 +5122,10 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -4903,7 +5133,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -4937,38 +5167,38 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -4976,7 +5206,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -5082,8 +5312,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -5091,7 +5328,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -5101,21 +5338,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -5123,32 +5360,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -5177,6 +5422,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -5198,14 +5444,26 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:dgs-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -5214,7 +5472,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -5225,7 +5483,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -5235,14 +5493,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -5250,48 +5508,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -5299,20 +5557,20 @@
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5322,7 +5580,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -5333,7 +5591,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -5350,20 +5608,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -5371,7 +5629,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -5385,31 +5643,31 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -15,7 +15,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -56,22 +56,24 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         }
     },
     "compileClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -85,7 +87,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -120,13 +122,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -144,48 +146,53 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.4",
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -195,13 +202,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -209,7 +216,7 @@
     },
     "implementationDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -223,7 +230,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -258,13 +265,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -279,48 +286,53 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.4",
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -330,13 +342,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -397,7 +409,7 @@
     },
     "jmhCompileClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -411,7 +423,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -446,13 +458,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -480,6 +492,13 @@
             "locked": "26.0.2",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.openjdk.jmh:jmh-core": {
@@ -519,45 +538,43 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -567,13 +584,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -651,7 +668,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -662,7 +679,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -672,7 +689,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -683,7 +700,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -691,7 +708,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -701,7 +718,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -711,7 +728,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -719,7 +736,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -737,7 +754,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -756,7 +773,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -859,48 +876,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -908,25 +925,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -938,7 +955,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -972,7 +989,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -980,7 +997,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -1026,19 +1043,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -1046,7 +1063,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -1142,8 +1159,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -1151,7 +1175,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -1161,21 +1185,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -1183,32 +1207,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -1266,6 +1298,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -1287,14 +1320,21 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1303,7 +1343,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter",
@@ -1311,7 +1351,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -1319,54 +1359,54 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1374,7 +1414,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1383,7 +1423,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1398,26 +1438,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1427,19 +1467,19 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1962,7 +2002,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1971,7 +2011,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1979,7 +2019,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -1987,21 +2027,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2017,7 +2057,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -2033,7 +2073,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2075,20 +2115,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -2171,6 +2211,13 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.ow2.asm:asm": {
             "locked": "9.7.1",
             "transitive": [
@@ -2181,6 +2228,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -2189,27 +2237,28 @@
             "locked": "2.0.17",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
-                "com.jayway.jsonpath:json-path"
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2217,14 +2266,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -2235,19 +2284,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
@@ -2267,7 +2316,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2277,7 +2326,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2287,7 +2336,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2297,28 +2346,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2329,7 +2378,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -2345,7 +2394,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2437,78 +2486,78 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -2534,7 +2583,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -2542,7 +2591,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -2583,19 +2632,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -2625,15 +2674,22 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -2641,21 +2697,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -2664,14 +2720,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2698,6 +2754,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -2717,13 +2774,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2732,14 +2788,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -2747,53 +2803,53 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2801,14 +2857,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2822,38 +2878,38 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2873,7 +2929,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2883,7 +2939,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2893,7 +2949,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2903,28 +2959,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2935,7 +2991,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -2951,7 +3007,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3043,48 +3099,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3110,14 +3166,14 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -3157,19 +3213,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -3196,15 +3252,22 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -3212,21 +3275,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -3235,14 +3298,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3263,6 +3326,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -3282,13 +3346,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3297,14 +3360,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -3312,53 +3375,53 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3366,14 +3429,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3387,38 +3450,38 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3445,7 +3508,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3456,7 +3519,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3466,7 +3529,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3477,7 +3540,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3485,7 +3548,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3495,7 +3558,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3505,7 +3568,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3513,7 +3576,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3531,7 +3594,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -3550,7 +3613,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3653,48 +3716,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3702,25 +3765,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3732,7 +3795,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3766,7 +3829,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -3774,7 +3837,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -3808,19 +3871,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -3828,7 +3891,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -3924,8 +3987,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -3933,7 +4003,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -3943,21 +4013,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -3965,32 +4035,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -4019,6 +4097,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -4040,14 +4119,21 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4056,7 +4142,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter",
@@ -4064,7 +4150,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -4072,54 +4158,54 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4127,7 +4213,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -4136,7 +4222,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4151,26 +4237,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4180,19 +4266,19 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/graphql-dgs-extended-scalars/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfiguration.kt
+++ b/graphql-dgs-extended-scalars/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfiguration.kt
@@ -21,6 +21,7 @@ import com.netflix.graphql.dgs.DgsRuntimeWiring
 import graphql.scalars.ExtendedScalars
 import graphql.schema.GraphQLScalarType
 import graphql.schema.idl.RuntimeWiring
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.AllNestedConditions
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
@@ -239,7 +240,15 @@ open class DgsExtendedScalarsAutoConfiguration {
     }
 
     abstract class AbstractExtendedScalarRegistrar : ExtendedScalarRegistrar {
+        /**
+         * Provide a mechanism to disable strict mode for scalar extensions; this will throw an exception if the scalar type is already registered.
+         * @see {@link https://github.com/graphql-java/graphql-java/commit/09f6a88c36affb1de56b3fe74b2a792b50ed941c}
+         */
+        @Value("\${dgs.graphql.extensions.scalars.strict-mode.enabled:false}")
+        private val strictModeEnabled: Boolean = false
+
         @DgsRuntimeWiring
-        fun addScalar(builder: RuntimeWiring.Builder): RuntimeWiring.Builder = getScalars().foldRight(builder) { a, acc -> acc.scalar(a) }
+        fun addScalar(builder: RuntimeWiring.Builder): RuntimeWiring.Builder =
+            getScalars().foldRight(builder.strictMode(strictModeEnabled)) { a, acc -> acc.scalar(a) }
     }
 }

--- a/graphql-dgs-extended-scalars/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/graphql-dgs-extended-scalars/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -35,6 +35,12 @@
       "name": "dgs.graphql.extensions.scalars.chars.enabled",
       "type": "java.lang.Boolean",
       "description": "Enabled by default, if dgs.graphql.extensions.scalars.enabled is enabled, will register the GraphQLChar extension."
+    },
+    {
+      "name": "dgs.graphql.extensions.scalars.strict-mode.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": "false",
+      "description": "Enables strict mode for scalar extensions; this will throw an exception if the scalar type is already registered."
     }
   ],
   "hints": []

--- a/graphql-dgs-extended-validation/dependencies.lock
+++ b/graphql-dgs-extended-validation/dependencies.lock
@@ -7,7 +7,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.graphql-java:graphql-java-extended-validation",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -29,7 +29,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -100,15 +100,17 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         }
@@ -121,7 +123,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.graphql-java:graphql-java-extended-validation",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -143,7 +145,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -178,13 +180,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -232,48 +234,53 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.4",
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -283,13 +290,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -303,7 +310,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.graphql-java:graphql-java-extended-validation",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -325,7 +332,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -360,13 +367,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -411,48 +418,53 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.4",
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -462,13 +474,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -535,7 +547,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.graphql-java:graphql-java-extended-validation",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -557,7 +569,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -592,13 +604,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -658,6 +670,13 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37",
             "transitive": [
@@ -695,45 +714,43 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -743,13 +760,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -827,7 +844,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -838,7 +855,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -848,7 +865,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -859,7 +876,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -867,7 +884,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -877,7 +894,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -887,7 +904,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -895,7 +912,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -919,7 +936,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -946,7 +963,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1049,48 +1066,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1098,25 +1115,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1128,7 +1145,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1174,7 +1191,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -1182,7 +1199,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -1228,13 +1245,13 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -1246,7 +1263,7 @@
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -1254,7 +1271,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -1362,8 +1379,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -1371,7 +1395,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -1381,21 +1405,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -1403,32 +1427,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -1486,6 +1518,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -1507,14 +1540,21 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1523,7 +1563,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter",
@@ -1531,7 +1571,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -1539,54 +1579,54 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1594,7 +1634,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1603,7 +1643,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1618,26 +1658,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1647,19 +1687,19 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2182,7 +2222,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2191,7 +2231,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2199,7 +2239,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2207,21 +2247,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2243,7 +2283,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -2267,7 +2307,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2309,20 +2349,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -2435,6 +2475,13 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.ow2.asm:asm": {
             "locked": "9.7.1",
             "transitive": [
@@ -2445,6 +2492,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -2453,27 +2501,28 @@
             "locked": "2.0.17",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
-                "com.jayway.jsonpath:json-path"
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2481,14 +2530,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -2499,19 +2548,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
@@ -2531,7 +2580,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2541,7 +2590,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2551,7 +2600,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2561,28 +2610,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2599,7 +2648,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.graphql-java:graphql-java-extended-validation",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2623,7 +2672,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2715,78 +2764,78 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -2824,7 +2873,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -2832,7 +2881,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -2873,13 +2922,13 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2891,7 +2940,7 @@
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -2933,15 +2982,22 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -2949,21 +3005,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -2972,14 +3028,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3006,6 +3062,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -3025,13 +3082,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3040,14 +3096,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -3055,53 +3111,53 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3109,14 +3165,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3130,38 +3186,38 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3181,7 +3237,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3191,7 +3247,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3201,7 +3257,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3211,28 +3267,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3249,7 +3305,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.graphql-java:graphql-java-extended-validation",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3273,7 +3329,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3365,48 +3421,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3444,14 +3500,14 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -3491,13 +3547,13 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3509,7 +3565,7 @@
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -3548,15 +3604,22 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -3564,21 +3627,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -3587,14 +3650,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3615,6 +3678,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -3634,13 +3698,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3649,14 +3712,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -3664,53 +3727,53 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3718,14 +3781,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3739,38 +3802,38 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3797,7 +3860,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3808,7 +3871,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3818,7 +3881,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3829,7 +3892,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3837,7 +3900,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3847,7 +3910,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3857,7 +3920,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3865,7 +3928,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3889,7 +3952,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -3916,7 +3979,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4019,48 +4082,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -4068,25 +4131,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4098,7 +4161,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4144,7 +4207,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -4152,7 +4215,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -4186,13 +4249,13 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -4204,7 +4267,7 @@
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -4212,7 +4275,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -4320,8 +4383,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -4329,7 +4399,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -4339,21 +4409,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -4361,32 +4431,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -4415,6 +4493,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -4436,14 +4515,21 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4452,7 +4538,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter",
@@ -4460,7 +4546,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -4468,54 +4554,54 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4523,7 +4609,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -4532,7 +4618,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4547,26 +4633,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4576,19 +4662,19 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -9,7 +9,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -50,22 +50,24 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         }
     },
     "compileClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -73,7 +75,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -108,13 +110,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -132,48 +134,53 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.4",
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -183,13 +190,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -197,7 +204,7 @@
     },
     "implementationDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -205,7 +212,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -240,13 +247,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -261,48 +268,53 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.4",
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -312,13 +324,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -379,7 +391,7 @@
     },
     "jmhCompileClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -387,7 +399,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -422,13 +434,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -456,6 +468,13 @@
             "locked": "26.0.2",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.openjdk.jmh:jmh-core": {
@@ -495,45 +514,43 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -543,13 +560,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -627,7 +644,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -636,7 +653,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -644,7 +661,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -652,21 +669,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -682,7 +699,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -691,7 +708,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -740,48 +757,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -789,31 +806,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -844,7 +861,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -852,7 +869,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -898,19 +915,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -918,7 +935,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -1001,8 +1018,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -1010,7 +1034,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -1020,21 +1044,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -1042,32 +1066,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -1125,6 +1157,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -1146,14 +1179,15 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1162,48 +1196,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1211,14 +1245,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1232,38 +1266,38 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1786,7 +1820,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1795,7 +1829,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1803,7 +1837,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -1811,21 +1845,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1841,7 +1875,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1850,7 +1884,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1892,20 +1926,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -1988,6 +2022,13 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.ow2.asm:asm": {
             "locked": "9.7.1",
             "transitive": [
@@ -1998,6 +2039,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -2006,27 +2048,28 @@
             "locked": "2.0.17",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
-                "com.jayway.jsonpath:json-path"
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2034,14 +2077,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -2052,19 +2095,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
@@ -2084,7 +2127,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -2092,7 +2135,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2134,71 +2177,71 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2222,7 +2265,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -2230,7 +2273,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -2271,19 +2314,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -2307,15 +2350,22 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -2323,21 +2373,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -2346,14 +2396,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2379,7 +2429,8 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.skyscreamer:jsonassert": {
@@ -2398,13 +2449,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2413,61 +2463,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2480,32 +2530,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2525,7 +2575,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -2533,7 +2583,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2575,41 +2625,41 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2633,14 +2683,14 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -2680,19 +2730,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -2713,15 +2763,22 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -2729,21 +2786,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -2752,14 +2809,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2779,7 +2836,8 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.skyscreamer:jsonassert": {
@@ -2798,13 +2856,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2813,61 +2870,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2880,32 +2937,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2932,7 +2989,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2941,7 +2998,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2949,7 +3006,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2957,21 +3014,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2987,7 +3044,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2996,7 +3053,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3045,48 +3102,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3094,31 +3151,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -3149,7 +3206,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -3157,7 +3214,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -3191,19 +3248,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -3211,7 +3268,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -3294,8 +3351,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -3303,7 +3367,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -3313,21 +3377,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -3335,32 +3399,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3389,6 +3461,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -3410,14 +3483,15 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3426,48 +3500,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3475,14 +3549,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3496,38 +3570,38 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -49,14 +49,14 @@ dependencies {
         // GraphQL Platform
         api("com.graphql-java:graphql-java") {
             version {
-                require("22.3")
+                require("24.0")
                 reject("[20.6, 19.5, 18.2]")
             }
 
         }
         api("com.graphql-java:java-dataloader") {
             version {
-                require("3.3.0")
+                require("5.0.0")
                 reject("[3.2.1]")
             }
 

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -9,7 +9,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -50,15 +50,17 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         }
@@ -77,7 +79,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -85,27 +87,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -114,7 +116,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -122,7 +124,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -157,13 +159,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -173,7 +175,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -241,10 +243,18 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -258,41 +268,40 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -301,13 +310,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -320,28 +329,28 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -361,20 +370,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "org.springframework:spring-webflux"
             ]
@@ -418,35 +427,35 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -455,13 +464,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -474,28 +483,28 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -503,7 +512,7 @@
     },
     "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -511,27 +520,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -540,7 +549,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -548,7 +557,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -586,7 +595,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions"
@@ -628,18 +637,23 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
+            "locked": "2.0.17"
         }
     },
     "jmh": {
@@ -709,7 +723,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -717,27 +731,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -746,7 +760,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -754,7 +768,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -789,13 +803,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -805,7 +819,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -885,6 +899,13 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37",
             "transitive": [
@@ -923,6 +944,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -936,41 +958,40 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -979,13 +1000,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -998,28 +1019,28 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1097,7 +1118,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1106,7 +1127,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1114,7 +1135,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -1122,21 +1143,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1152,7 +1173,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1161,7 +1182,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1210,48 +1231,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1259,25 +1280,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1286,7 +1307,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -1295,7 +1316,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1325,7 +1346,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -1333,7 +1354,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -1379,19 +1400,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -1399,7 +1420,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -1482,8 +1503,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -1491,7 +1519,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -1501,21 +1529,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -1523,32 +1551,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -1606,6 +1642,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -1627,14 +1664,15 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1643,48 +1681,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1692,14 +1730,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1713,38 +1751,38 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2267,7 +2305,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2276,7 +2314,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2284,7 +2322,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2292,21 +2330,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2322,7 +2360,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2331,7 +2369,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2373,13 +2411,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2389,7 +2427,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -2473,6 +2511,13 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.ow2.asm:asm": {
             "locked": "9.7.1",
             "transitive": [
@@ -2483,6 +2528,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -2491,18 +2537,19 @@
             "locked": "2.0.17",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
-                "com.jayway.jsonpath:json-path"
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2510,13 +2557,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -2526,19 +2573,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
@@ -2558,7 +2605,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2566,27 +2613,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2595,7 +2642,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -2603,7 +2650,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2645,71 +2692,71 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2718,7 +2765,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -2726,7 +2773,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2750,7 +2797,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -2758,7 +2805,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -2799,19 +2846,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -2863,15 +2910,22 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -2879,21 +2933,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -2902,14 +2956,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2936,6 +2990,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -2955,13 +3010,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2970,61 +3024,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3037,32 +3091,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3082,7 +3136,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -3090,27 +3144,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3119,7 +3173,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3127,7 +3181,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3169,41 +3223,41 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3212,7 +3266,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -3220,7 +3274,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3244,14 +3298,14 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -3291,19 +3345,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -3350,15 +3404,22 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -3366,21 +3427,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -3389,14 +3450,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3417,6 +3478,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -3436,13 +3498,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3451,61 +3512,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3518,32 +3579,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3570,7 +3631,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3579,7 +3640,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3587,7 +3648,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -3595,21 +3656,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3625,7 +3686,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3634,7 +3695,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3683,48 +3744,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3732,25 +3793,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3759,7 +3820,7 @@
             "locked": "1.2.3"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -3768,7 +3829,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3798,7 +3859,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -3806,7 +3867,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -3840,19 +3901,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -3860,7 +3921,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -3943,8 +4004,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -3952,7 +4020,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -3962,21 +4030,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -3984,32 +4052,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -4038,6 +4114,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -4059,14 +4136,15 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4075,48 +4153,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4124,14 +4202,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4145,38 +4223,38 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -9,7 +9,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -50,15 +50,17 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         }
@@ -77,7 +79,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -85,7 +87,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -95,7 +97,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -105,28 +107,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -137,16 +139,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -154,7 +156,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -189,23 +191,23 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.12"
+            "locked": "1.8.13"
         },
         "commons-codec:commons-codec": {
-            "locked": "1.17.2"
+            "locked": "1.18.0"
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6"
+            "locked": "1.15.0"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -234,28 +236,22 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -271,10 +267,19 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
@@ -287,13 +292,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -302,58 +306,58 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -363,7 +367,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-context-support",
@@ -371,10 +375,10 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -388,20 +392,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -409,13 +413,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -435,7 +439,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -443,7 +447,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -453,7 +457,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -463,28 +467,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -495,13 +499,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -527,20 +531,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -560,7 +564,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -569,58 +573,58 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -629,14 +633,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -649,20 +653,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -670,13 +674,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -684,16 +688,16 @@
     },
     "implementationDependenciesMetadata": {
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -701,7 +705,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -736,32 +740,26 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.12"
+            "locked": "1.8.13"
         },
         "commons-codec:commons-codec": {
-            "locked": "1.17.2"
+            "locked": "1.18.0"
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6"
+            "locked": "1.15.0"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -774,26 +772,32 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.4",
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -801,16 +805,16 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context-support"
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -820,13 +824,13 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -899,7 +903,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -907,7 +911,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -917,7 +921,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -927,28 +931,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -959,16 +963,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -976,7 +980,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1011,23 +1015,23 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.12"
+            "locked": "1.8.13"
         },
         "commons-codec:commons-codec": {
-            "locked": "1.17.2"
+            "locked": "1.18.0"
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6"
+            "locked": "1.15.0"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -1068,28 +1072,22 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1103,6 +1101,14 @@
             "locked": "26.0.2",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.openjdk.jmh:jmh-core": {
@@ -1142,7 +1148,8 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
@@ -1155,13 +1162,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -1170,58 +1176,58 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1231,7 +1237,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-context-support",
@@ -1239,10 +1245,10 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1256,20 +1262,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -1277,13 +1283,13 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1361,7 +1367,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1372,7 +1378,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1382,7 +1388,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1394,7 +1400,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1402,7 +1408,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1413,7 +1419,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1423,7 +1429,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1431,7 +1437,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1443,10 +1449,10 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
@@ -1458,7 +1464,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1470,7 +1476,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1558,7 +1564,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.12"
+            "locked": "1.8.13"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -1567,7 +1573,7 @@
             ]
         },
         "commons-codec:commons-codec": {
-            "locked": "1.17.2"
+            "locked": "1.18.0"
         },
         "io.micrometer:context-propagation": {
             "locked": "1.1.3",
@@ -1579,17 +1585,17 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6"
+            "locked": "1.15.0"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -1597,35 +1603,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1633,25 +1639,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1663,7 +1669,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1698,7 +1704,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -1706,7 +1712,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -1752,44 +1758,38 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -1797,7 +1797,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -1899,8 +1899,16 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -1908,7 +1916,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -1918,21 +1926,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -1940,21 +1948,29 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.latencyutils:LatencyUtils": {
@@ -1964,14 +1980,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2029,6 +2045,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -2050,15 +2067,22 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -2069,16 +2093,16 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -2087,7 +2111,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -2096,65 +2120,65 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2164,7 +2188,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -2175,10 +2199,10 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2195,27 +2219,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2227,25 +2251,25 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2768,7 +2792,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2777,7 +2801,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2785,7 +2809,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2793,21 +2817,21 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2817,10 +2841,10 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
@@ -2832,7 +2856,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2841,7 +2865,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2876,10 +2900,10 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.12"
+            "locked": "1.8.13"
         },
         "commons-codec:commons-codec": {
-            "locked": "1.17.2"
+            "locked": "1.18.0"
         },
         "io.micrometer:context-propagation": {
             "locked": "1.1.3",
@@ -2889,17 +2913,17 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6"
+            "locked": "1.15.0"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -2907,7 +2931,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -2923,12 +2947,6 @@
             "locked": "2.5.2",
             "transitive": [
                 "com.jayway.jsonpath:json-path"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -3002,6 +3020,14 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.latencyutils:LatencyUtils": {
             "locked": "2.0.3",
             "transitive": [
@@ -3018,6 +3044,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -3026,19 +3053,20 @@
             "locked": "2.0.17",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "com.netflix.spectator:spectator-api"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3047,17 +3075,17 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework:spring-context-support"
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -3068,19 +3096,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
@@ -3100,7 +3128,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3110,7 +3138,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3120,7 +3148,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3130,28 +3158,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3162,16 +3190,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3181,7 +3209,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3267,7 +3295,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.12"
+            "locked": "1.8.13"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -3276,20 +3304,20 @@
             ]
         },
         "commons-codec:commons-codec": {
-            "locked": "1.17.2"
+            "locked": "1.18.0"
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6"
+            "locked": "1.15.0"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -3297,65 +3325,65 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3382,7 +3410,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -3390,7 +3418,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -3423,20 +3451,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3450,25 +3478,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -3498,15 +3520,23 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -3514,21 +3544,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -3537,14 +3567,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3571,6 +3601,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -3590,13 +3621,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -3607,16 +3637,16 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3624,7 +3654,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -3633,64 +3663,64 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3700,7 +3730,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -3709,10 +3739,10 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3728,27 +3758,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3756,19 +3786,19 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3788,7 +3818,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3798,7 +3828,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3808,7 +3838,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3818,28 +3848,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3850,16 +3880,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3869,7 +3899,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3955,7 +3985,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.12"
+            "locked": "1.8.13"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -3964,20 +3994,20 @@
             ]
         },
         "commons-codec:commons-codec": {
-            "locked": "1.17.2"
+            "locked": "1.18.0"
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6"
+            "locked": "1.15.0"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -3985,35 +4015,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4040,14 +4070,14 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -4079,20 +4109,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -4106,25 +4136,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -4151,15 +4175,23 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -4167,21 +4199,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -4190,14 +4222,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -4218,6 +4250,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -4237,13 +4270,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -4254,16 +4286,16 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4271,7 +4303,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -4280,64 +4312,64 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4347,7 +4379,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -4356,10 +4388,10 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4375,27 +4407,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -4403,19 +4435,19 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -4442,7 +4474,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4453,7 +4485,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -4463,7 +4495,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4475,7 +4507,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4483,7 +4515,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4494,7 +4526,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4504,7 +4536,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4512,7 +4544,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4524,10 +4556,10 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
@@ -4539,7 +4571,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4551,7 +4583,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4639,7 +4671,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.12"
+            "locked": "1.8.13"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -4648,7 +4680,7 @@
             ]
         },
         "commons-codec:commons-codec": {
-            "locked": "1.17.2"
+            "locked": "1.18.0"
         },
         "io.micrometer:context-propagation": {
             "locked": "1.1.3",
@@ -4660,17 +4692,17 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6"
+            "locked": "1.15.0"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -4678,35 +4710,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -4714,25 +4746,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4744,7 +4776,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4779,7 +4811,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -4787,7 +4819,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -4821,44 +4853,38 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -4866,7 +4892,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -4968,8 +4994,16 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -4977,7 +5011,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -4987,21 +5021,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -5009,21 +5043,29 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.latencyutils:LatencyUtils": {
@@ -5033,14 +5075,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -5069,6 +5111,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -5090,15 +5133,22 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -5109,16 +5159,16 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -5127,7 +5177,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -5136,65 +5186,65 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5204,7 +5254,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -5215,10 +5265,10 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -5235,27 +5285,27 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -5267,25 +5317,25 @@
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/graphql-dgs-spring-graphql-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-spring-graphql-example-java-webflux/dependencies.lock
@@ -21,7 +21,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -31,7 +31,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -41,7 +41,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -51,28 +51,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -83,16 +83,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -102,7 +102,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -207,7 +207,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -215,19 +215,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -237,7 +237,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -254,7 +254,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -266,13 +266,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -280,19 +280,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -312,7 +312,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -321,13 +321,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -335,7 +335,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -343,20 +343,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -372,20 +372,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -394,19 +394,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -423,7 +423,7 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.24.3",
@@ -437,12 +437,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.boot:spring-boot-starter-logging"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -467,10 +461,19 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -484,13 +487,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -499,26 +501,26 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -527,51 +529,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -580,14 +582,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -600,19 +602,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -620,13 +622,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -646,7 +648,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -656,7 +658,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -666,7 +668,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -676,28 +678,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -708,16 +710,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -727,7 +729,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -832,7 +834,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -840,19 +842,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -862,7 +864,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -879,7 +881,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -891,13 +893,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -905,19 +907,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -937,7 +939,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -946,13 +948,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -960,7 +962,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -968,20 +970,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -997,20 +999,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -1019,19 +1021,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1048,7 +1050,7 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.24.3",
@@ -1062,12 +1064,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.boot:spring-boot-starter-logging"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1089,10 +1085,19 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -1106,13 +1111,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -1121,26 +1125,26 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -1149,51 +1153,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1202,14 +1206,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1222,19 +1226,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -1242,13 +1246,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1321,7 +1325,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1331,7 +1335,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1341,7 +1345,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1351,28 +1355,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1383,16 +1387,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1402,7 +1406,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1507,7 +1511,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -1515,19 +1519,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -1537,7 +1541,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -1554,7 +1558,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -1566,13 +1570,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1580,19 +1584,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -1612,7 +1616,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -1621,13 +1625,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -1635,7 +1639,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -1643,20 +1647,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -1672,20 +1676,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -1694,19 +1698,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1723,7 +1727,7 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "net.sf.jopt-simple:jopt-simple": {
             "locked": "5.0.4",
@@ -1751,12 +1755,6 @@
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.20",
             "transitive": [
@@ -1777,6 +1775,14 @@
             "locked": "26.0.2",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.openjdk.jmh:jmh-core": {
@@ -1817,6 +1823,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -1830,13 +1837,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -1845,26 +1851,26 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -1873,51 +1879,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1926,14 +1932,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1946,19 +1952,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -1966,13 +1972,13 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2050,7 +2056,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2061,7 +2067,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2071,7 +2077,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2084,7 +2090,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2092,7 +2098,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2103,7 +2109,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2113,7 +2119,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2121,7 +2127,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2133,13 +2139,13 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
+            "locked": "3.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
@@ -2151,7 +2157,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -2172,7 +2178,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2290,7 +2296,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.12",
+            "locked": "1.8.13",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -2302,7 +2308,7 @@
             ]
         },
         "commons-codec:commons-codec": {
-            "locked": "1.17.2",
+            "locked": "1.18.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -2317,7 +2323,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -2325,20 +2331,20 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -2348,35 +2354,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -2384,31 +2390,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2425,7 +2431,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -2437,13 +2443,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2451,19 +2457,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -2483,7 +2489,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -2492,13 +2498,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -2506,7 +2512,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -2514,20 +2520,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2543,20 +2549,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -2571,19 +2577,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -2598,7 +2604,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2628,10 +2634,10 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -2639,7 +2645,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -2685,25 +2691,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -2711,7 +2711,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -2821,8 +2821,16 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -2830,7 +2838,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -2840,21 +2848,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -2862,21 +2870,29 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.latencyutils:LatencyUtils": {
@@ -2886,14 +2902,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2951,6 +2967,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -2972,15 +2989,26 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -2991,19 +3019,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -3014,7 +3042,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -3024,68 +3052,68 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3095,7 +3123,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -3106,13 +3134,13 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3129,26 +3157,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3161,26 +3189,26 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3715,7 +3743,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3726,7 +3754,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3736,7 +3764,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3749,7 +3777,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3757,7 +3785,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3768,7 +3796,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3778,7 +3806,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3786,7 +3814,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3798,13 +3826,13 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
+            "locked": "3.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
@@ -3816,7 +3844,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -3837,7 +3865,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3954,13 +3982,13 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.12",
+            "locked": "1.8.13",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "commons-codec:commons-codec": {
-            "locked": "1.17.2",
+            "locked": "1.18.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -3975,7 +4003,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -3983,20 +4011,20 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -4006,7 +4034,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4023,7 +4051,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -4035,13 +4063,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4049,19 +4077,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -4081,7 +4109,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -4090,13 +4118,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -4104,7 +4132,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -4112,20 +4140,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4141,20 +4169,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -4169,19 +4197,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -4201,7 +4229,7 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "net.minidev:accessors-smart": {
             "locked": "2.5.2",
@@ -4227,12 +4255,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.boot:spring-boot-starter-logging"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -4327,6 +4349,14 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.latencyutils:LatencyUtils": {
             "locked": "2.0.3",
             "transitive": [
@@ -4343,6 +4373,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -4358,15 +4389,26 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -4375,19 +4417,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -4397,7 +4439,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -4406,52 +4448,52 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4461,7 +4503,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -4472,13 +4514,13 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4493,19 +4535,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4518,20 +4560,20 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -4551,7 +4593,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4561,7 +4603,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -4571,7 +4613,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4581,28 +4623,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4613,16 +4655,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4632,7 +4674,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4744,7 +4786,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -4752,19 +4794,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -4774,65 +4816,65 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4849,7 +4891,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -4861,13 +4903,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4875,19 +4917,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -4907,7 +4949,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -4916,13 +4958,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -4930,7 +4972,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -4938,20 +4980,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4967,20 +5009,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -4989,19 +5031,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -5013,7 +5055,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -5037,10 +5079,10 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -5048,7 +5090,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -5089,25 +5131,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -5140,15 +5176,23 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -5156,21 +5200,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -5179,14 +5223,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -5213,6 +5257,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -5232,13 +5277,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -5249,19 +5293,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -5269,7 +5313,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -5279,67 +5323,67 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5348,14 +5392,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -5370,26 +5414,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -5397,19 +5441,19 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -5429,7 +5473,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5439,7 +5483,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -5449,7 +5493,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5459,28 +5503,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -5491,16 +5535,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -5510,7 +5554,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -5622,7 +5666,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -5630,19 +5674,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -5652,35 +5696,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -5697,7 +5741,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -5709,13 +5753,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5723,19 +5767,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -5755,7 +5799,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -5764,13 +5808,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -5778,7 +5822,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -5786,20 +5830,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -5815,20 +5859,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -5837,19 +5881,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -5861,7 +5905,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -5885,17 +5929,17 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -5935,25 +5979,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -5983,15 +6021,23 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -5999,21 +6045,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -6022,14 +6068,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -6050,6 +6096,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -6069,13 +6116,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -6086,19 +6132,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -6106,7 +6152,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -6116,67 +6162,67 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -6185,14 +6231,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -6207,26 +6253,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -6234,19 +6280,19 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -6273,7 +6319,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -6284,7 +6330,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -6294,7 +6340,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -6307,7 +6353,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -6315,7 +6361,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -6326,7 +6372,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -6336,7 +6382,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -6344,7 +6390,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -6356,13 +6402,13 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
+            "locked": "3.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
@@ -6374,7 +6420,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -6395,7 +6441,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -6513,7 +6559,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.12",
+            "locked": "1.8.13",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -6525,7 +6571,7 @@
             ]
         },
         "commons-codec:commons-codec": {
-            "locked": "1.17.2",
+            "locked": "1.18.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -6540,7 +6586,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -6548,20 +6594,20 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -6571,35 +6617,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -6607,31 +6653,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -6648,7 +6694,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -6660,13 +6706,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -6674,19 +6720,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -6706,7 +6752,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -6715,13 +6761,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -6729,7 +6775,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -6737,20 +6783,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -6766,20 +6812,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -6794,19 +6840,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -6821,7 +6867,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -6851,10 +6897,10 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -6862,7 +6908,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -6896,25 +6942,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -6922,7 +6962,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -7032,8 +7072,16 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -7041,7 +7089,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -7051,21 +7099,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -7073,21 +7121,29 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.latencyutils:LatencyUtils": {
@@ -7097,14 +7153,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -7133,6 +7189,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -7154,15 +7211,26 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -7173,19 +7241,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -7196,7 +7264,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -7206,68 +7274,68 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -7277,7 +7345,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -7288,13 +7356,13 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -7311,26 +7379,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -7343,26 +7411,26 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/graphql-dgs-spring-graphql-example-java/dependencies.lock
+++ b/graphql-dgs-spring-graphql-example-java/dependencies.lock
@@ -21,7 +21,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -31,7 +31,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -41,7 +41,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -51,28 +51,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -83,16 +83,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -102,7 +102,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -199,7 +199,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -207,19 +207,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -229,7 +229,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -246,7 +246,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -258,13 +258,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -272,19 +272,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -304,7 +304,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -313,13 +313,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -327,7 +327,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -335,20 +335,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -364,20 +364,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -386,19 +386,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -416,7 +416,7 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.24.3",
@@ -433,28 +433,22 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -478,10 +472,19 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -495,13 +498,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -510,26 +512,26 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -539,17 +541,17 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -557,44 +559,44 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -604,7 +606,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -612,7 +614,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -626,20 +628,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -649,19 +651,19 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -681,7 +683,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -691,7 +693,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -701,7 +703,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -711,28 +713,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -743,16 +745,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -762,7 +764,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -859,7 +861,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -867,19 +869,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -889,7 +891,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -906,7 +908,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -918,13 +920,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -932,19 +934,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -964,7 +966,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -973,13 +975,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -987,7 +989,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -995,20 +997,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -1024,20 +1026,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -1046,19 +1048,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1076,7 +1078,7 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "org.apache.logging.log4j:log4j-api": {
             "locked": "2.24.3",
@@ -1093,28 +1095,22 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1135,10 +1131,19 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -1152,13 +1157,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -1167,26 +1171,26 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -1196,17 +1200,17 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -1214,44 +1218,44 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1261,7 +1265,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -1269,7 +1273,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1283,20 +1287,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -1306,19 +1310,19 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1391,7 +1395,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1401,7 +1405,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1411,7 +1415,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1421,28 +1425,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1453,16 +1457,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1472,7 +1476,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1569,7 +1573,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -1577,19 +1581,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -1599,7 +1603,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -1616,7 +1620,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -1628,13 +1632,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -1642,19 +1646,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -1674,7 +1678,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -1683,13 +1687,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -1697,7 +1701,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -1705,20 +1709,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -1734,20 +1738,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -1756,19 +1760,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1786,7 +1790,7 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "net.sf.jopt-simple:jopt-simple": {
             "locked": "5.0.4",
@@ -1815,28 +1819,22 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1858,6 +1856,14 @@
             "locked": "26.0.2",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.openjdk.jmh:jmh-core": {
@@ -1898,6 +1904,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -1911,13 +1918,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -1926,26 +1932,26 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -1955,17 +1961,17 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -1973,44 +1979,44 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2020,7 +2026,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -2028,7 +2034,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2042,20 +2048,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -2065,19 +2071,19 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2155,7 +2161,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2166,7 +2172,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2176,7 +2182,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2189,7 +2195,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2197,7 +2203,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2208,7 +2214,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2218,7 +2224,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2226,7 +2232,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2238,13 +2244,13 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
+            "locked": "3.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
@@ -2256,7 +2262,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -2278,7 +2284,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2420,7 +2426,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.12",
+            "locked": "1.8.13",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -2432,7 +2438,7 @@
             ]
         },
         "commons-codec:commons-codec": {
-            "locked": "1.17.2",
+            "locked": "1.18.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -2447,7 +2453,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -2455,20 +2461,20 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -2478,35 +2484,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -2514,31 +2520,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2555,7 +2561,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -2567,13 +2573,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -2581,19 +2587,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -2613,7 +2619,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -2622,13 +2628,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -2636,7 +2642,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -2644,20 +2650,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -2673,20 +2679,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -2701,19 +2707,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -2729,7 +2735,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2760,10 +2766,10 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -2771,7 +2777,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -2817,44 +2823,38 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -2862,7 +2862,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -2978,8 +2978,16 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -2987,7 +2995,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -2997,21 +3005,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -3019,21 +3027,29 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.latencyutils:LatencyUtils": {
@@ -3043,14 +3059,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3108,6 +3124,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -3129,15 +3146,29 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:dgs-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -3148,19 +3179,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -3172,7 +3203,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -3183,17 +3214,17 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3201,48 +3232,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -3256,14 +3287,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3274,7 +3305,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -3287,13 +3318,13 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3311,20 +3342,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -3332,7 +3363,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3347,32 +3378,32 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3907,7 +3938,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3918,7 +3949,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3928,7 +3959,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3941,7 +3972,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3949,7 +3980,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3960,7 +3991,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3970,7 +4001,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3978,7 +4009,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3990,13 +4021,13 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
+            "locked": "3.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
@@ -4008,7 +4039,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -4029,7 +4060,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4146,13 +4177,13 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.12",
+            "locked": "1.8.13",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "commons-codec:commons-codec": {
-            "locked": "1.17.2",
+            "locked": "1.18.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -4167,7 +4198,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -4175,20 +4206,20 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -4198,7 +4229,7 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4215,7 +4246,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -4227,13 +4258,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -4241,19 +4272,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -4273,7 +4304,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -4282,13 +4313,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -4296,7 +4327,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -4304,20 +4335,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -4333,20 +4364,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -4361,19 +4392,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -4394,7 +4425,7 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "net.minidev:accessors-smart": {
             "locked": "2.5.2",
@@ -4423,28 +4454,22 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -4539,6 +4564,14 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.latencyutils:LatencyUtils": {
             "locked": "2.0.3",
             "transitive": [
@@ -4555,6 +4588,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -4570,15 +4604,26 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -4587,19 +4632,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -4609,7 +4654,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -4619,17 +4664,17 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -4637,45 +4682,45 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4686,7 +4731,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -4698,13 +4743,13 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4720,20 +4765,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4748,26 +4793,26 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -4787,7 +4832,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4797,7 +4842,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -4807,7 +4852,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4817,28 +4862,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4849,16 +4894,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4876,7 +4921,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -5020,7 +5065,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -5028,19 +5073,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -5050,65 +5095,65 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -5125,7 +5170,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -5137,13 +5182,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -5151,19 +5196,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -5183,7 +5228,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -5192,13 +5237,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -5206,7 +5251,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -5214,20 +5259,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -5243,20 +5288,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -5265,19 +5310,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -5290,7 +5335,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -5315,10 +5360,10 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -5326,7 +5371,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -5359,20 +5404,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -5386,25 +5431,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -5441,15 +5480,23 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -5457,21 +5504,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -5480,14 +5527,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -5514,6 +5561,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -5533,13 +5581,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -5550,19 +5597,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -5570,7 +5617,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -5581,17 +5628,17 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -5599,47 +5646,47 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.graphql:spring-graphql-test"
@@ -5652,14 +5699,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5669,7 +5716,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -5678,7 +5725,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -5694,20 +5741,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -5715,7 +5762,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -5725,25 +5772,25 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -5763,7 +5810,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5773,7 +5820,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -5783,7 +5830,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -5793,28 +5840,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -5825,16 +5872,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -5852,7 +5899,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -5996,7 +6043,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -6004,19 +6051,19 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -6026,35 +6073,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -6071,7 +6118,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -6083,13 +6130,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -6097,19 +6144,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -6129,7 +6176,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -6138,13 +6185,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -6152,7 +6199,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -6160,20 +6207,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -6189,20 +6236,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -6211,19 +6258,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -6236,7 +6283,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -6261,17 +6308,17 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -6303,20 +6350,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -6330,25 +6377,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -6382,15 +6423,23 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -6398,21 +6447,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -6421,14 +6470,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -6449,6 +6498,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -6468,13 +6518,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -6485,19 +6534,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -6505,7 +6554,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -6516,17 +6565,17 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -6534,47 +6583,47 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.graphql:spring-graphql-test"
@@ -6587,14 +6636,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -6604,7 +6653,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -6613,7 +6662,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -6629,20 +6678,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -6650,7 +6699,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -6660,25 +6709,25 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -6705,7 +6754,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -6716,7 +6765,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -6726,7 +6775,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -6739,7 +6788,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -6747,7 +6796,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -6758,7 +6807,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -6768,7 +6817,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -6776,7 +6825,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -6788,13 +6837,13 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
+            "locked": "3.2.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
@@ -6806,7 +6855,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -6828,7 +6877,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -6970,7 +7019,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.12",
+            "locked": "1.8.13",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -6982,7 +7031,7 @@
             ]
         },
         "commons-codec:commons-codec": {
-            "locked": "1.17.2",
+            "locked": "1.18.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -6997,7 +7046,7 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -7005,20 +7054,20 @@
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
@@ -7028,35 +7077,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -7064,31 +7113,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -7105,7 +7154,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-dns",
                 "io.netty:netty-codec-http",
@@ -7117,13 +7166,13 @@
             ]
         },
         "io.netty:netty-codec-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
@@ -7131,19 +7180,19 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-buffer",
                 "io.netty:netty-codec",
@@ -7163,7 +7212,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
@@ -7172,13 +7221,13 @@
             ]
         },
         "io.netty:netty-handler-proxy": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
@@ -7186,7 +7235,7 @@
             ]
         },
         "io.netty:netty-resolver-dns": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
@@ -7194,20 +7243,20 @@
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-codec-dns",
@@ -7223,20 +7272,20 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.119.Final",
+            "locked": "4.1.121.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
@@ -7251,19 +7300,19 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
-            "locked": "1.2.5",
+            "locked": "1.2.6",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -7279,7 +7328,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -7310,10 +7359,10 @@
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.5.3"
+            "locked": "1.6.0"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -7321,7 +7370,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -7355,44 +7404,38 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -7400,7 +7443,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -7516,8 +7559,16 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -7525,7 +7576,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -7535,21 +7586,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -7557,21 +7608,29 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.latencyutils:LatencyUtils": {
@@ -7581,14 +7640,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -7617,6 +7676,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -7638,15 +7698,29 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:dgs-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
@@ -7657,19 +7731,19 @@
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
@@ -7681,7 +7755,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -7692,17 +7766,17 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter",
                 "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -7710,48 +7784,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql",
@@ -7765,14 +7839,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -7783,7 +7857,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
@@ -7796,13 +7870,13 @@
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -7820,20 +7894,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -7841,7 +7915,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -7856,32 +7930,32 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/graphql-dgs-spring-graphql-starter-test/dependencies.lock
+++ b/graphql-dgs-spring-graphql-starter-test/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -9,7 +9,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -43,19 +43,19 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -69,53 +69,55 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
-        },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -125,19 +127,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -145,7 +147,7 @@
     },
     "compileClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -153,7 +155,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -187,19 +189,19 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -219,53 +221,58 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
+            "locked": "2.0.17"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -275,19 +282,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -295,7 +302,7 @@
     },
     "implementationDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -303,7 +310,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -337,19 +344,19 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -366,53 +373,58 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
+            "locked": "2.0.17"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -422,19 +434,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -495,7 +507,7 @@
     },
     "jmhCompileClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -503,7 +515,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -537,19 +549,19 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -579,6 +591,13 @@
             "locked": "26.0.2",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.openjdk.jmh:jmh-core": {
@@ -619,49 +638,47 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
+            "locked": "2.0.17"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -671,19 +688,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -754,7 +771,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -762,7 +779,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -810,47 +827,47 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -858,31 +875,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -914,7 +931,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -922,7 +939,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -968,19 +985,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -988,7 +1005,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -1048,8 +1065,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -1057,7 +1081,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -1067,21 +1091,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -1089,32 +1113,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -1172,6 +1204,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -1191,14 +1224,15 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1207,7 +1241,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter",
@@ -1215,61 +1249,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -1277,7 +1311,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1290,19 +1324,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -1310,13 +1344,13 @@
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1832,7 +1866,7 @@
     },
     "runtimeClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -1840,7 +1874,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1881,19 +1915,19 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -1927,6 +1961,13 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.ow2.asm:asm": {
             "locked": "9.7.1",
             "transitive": [
@@ -1937,18 +1978,20 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "com.jayway.jsonpath:json-path"
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-test",
@@ -1956,51 +1999,51 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -2008,7 +2051,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -2019,19 +2062,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.graphql:spring-graphql-test"
@@ -2052,7 +2095,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -2060,7 +2103,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2101,77 +2144,77 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -2197,7 +2240,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -2205,7 +2248,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -2246,19 +2289,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -2282,15 +2325,22 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -2298,21 +2348,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -2321,14 +2371,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2355,6 +2405,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -2374,13 +2425,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2389,67 +2439,67 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -2457,7 +2507,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2470,19 +2520,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -2490,13 +2540,13 @@
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2516,7 +2566,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -2524,7 +2574,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2565,47 +2615,47 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -2631,14 +2681,14 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -2678,19 +2728,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -2711,15 +2761,22 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -2727,21 +2784,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -2750,14 +2807,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2778,6 +2835,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -2797,13 +2855,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2812,67 +2869,67 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -2880,7 +2937,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2893,19 +2950,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -2913,13 +2970,13 @@
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2939,7 +2996,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -2947,7 +3004,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2995,47 +3052,47 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3043,31 +3100,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -3099,7 +3156,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -3107,7 +3164,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -3141,19 +3198,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -3161,7 +3218,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -3221,8 +3278,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -3230,7 +3294,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -3240,21 +3304,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -3262,32 +3326,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3316,6 +3388,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -3335,14 +3408,15 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3351,7 +3425,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter",
@@ -3359,61 +3433,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -3421,7 +3495,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3434,19 +3508,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -3454,13 +3528,13 @@
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/graphql-dgs-spring-graphql-starter/dependencies.lock
+++ b/graphql-dgs-spring-graphql-starter/dependencies.lock
@@ -13,7 +13,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -23,7 +23,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -33,7 +33,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -43,28 +43,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -75,7 +75,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -85,7 +85,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -162,20 +162,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -214,10 +214,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -231,63 +239,62 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -295,14 +302,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -314,25 +321,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -352,7 +359,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -362,7 +369,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -372,7 +379,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -382,28 +389,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -414,7 +421,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -424,7 +431,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -501,20 +508,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -559,10 +566,18 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -576,63 +591,62 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -640,14 +654,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -659,25 +673,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -697,7 +711,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -707,7 +721,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -717,7 +731,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -727,28 +741,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -759,7 +773,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -769,7 +783,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -846,20 +860,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -901,10 +915,18 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -918,63 +940,62 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -982,14 +1003,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1001,25 +1022,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1092,7 +1113,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1102,7 +1123,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1112,7 +1133,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1122,28 +1143,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1154,7 +1175,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1164,7 +1185,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1241,20 +1262,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1311,6 +1332,13 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37",
             "transitive": [
@@ -1349,6 +1377,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -1362,63 +1391,62 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1426,14 +1454,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1445,25 +1473,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1541,7 +1569,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1552,7 +1580,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1562,7 +1590,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1573,7 +1601,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1581,7 +1609,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1591,7 +1619,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1601,7 +1629,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -1609,7 +1637,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1627,7 +1655,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1639,7 +1667,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1734,48 +1762,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1783,25 +1811,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1813,7 +1841,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -1847,7 +1875,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -1855,7 +1883,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -1901,19 +1929,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -1921,7 +1949,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -2015,8 +2043,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -2024,7 +2059,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -2034,21 +2069,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -2056,32 +2091,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2139,6 +2182,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -2160,14 +2204,20 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2176,7 +2226,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter",
@@ -2184,7 +2234,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -2192,54 +2242,54 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2247,7 +2297,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -2256,7 +2306,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2271,26 +2321,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2300,19 +2350,19 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2847,7 +2897,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2858,7 +2908,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2868,7 +2918,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2879,7 +2929,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2887,7 +2937,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2897,7 +2947,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2907,7 +2957,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -2915,7 +2965,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2933,7 +2983,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2945,7 +2995,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3033,13 +3083,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3052,7 +3102,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3169,6 +3219,13 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.ow2.asm:asm": {
             "locked": "9.7.1",
             "transitive": [
@@ -3179,6 +3236,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -3194,66 +3252,72 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3261,7 +3325,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -3270,7 +3334,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3283,19 +3347,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -3305,13 +3369,13 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3331,7 +3395,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3341,7 +3405,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3351,7 +3415,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3361,28 +3425,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3393,7 +3457,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3403,7 +3467,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3487,78 +3551,78 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3584,7 +3648,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -3592,7 +3656,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -3633,19 +3697,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -3674,15 +3738,22 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -3690,21 +3761,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -3713,14 +3784,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3747,6 +3818,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -3766,13 +3838,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3781,14 +3852,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -3796,53 +3867,53 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3850,14 +3921,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3871,38 +3942,38 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3922,7 +3993,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3932,7 +4003,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3942,7 +4013,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3952,28 +4023,28 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3984,7 +4055,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3994,7 +4065,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4078,48 +4149,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4145,14 +4216,14 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -4192,19 +4263,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -4230,15 +4301,22 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -4246,21 +4324,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -4269,14 +4347,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -4297,6 +4375,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -4316,13 +4395,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4331,14 +4409,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -4346,53 +4424,53 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4400,14 +4478,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4421,38 +4499,38 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -4479,7 +4557,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4490,7 +4568,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -4500,7 +4578,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4511,7 +4589,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4519,7 +4597,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4529,7 +4607,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4539,7 +4617,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -4547,7 +4625,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4565,7 +4643,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4577,7 +4655,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4672,48 +4750,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -4721,25 +4799,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4751,7 +4829,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -4785,7 +4863,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -4793,7 +4871,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -4827,19 +4905,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -4847,7 +4925,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -4941,8 +5019,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -4950,7 +5035,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -4960,21 +5045,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -4982,32 +5067,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -5036,6 +5129,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -5057,14 +5151,20 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -5073,7 +5173,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter",
@@ -5081,7 +5181,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -5089,54 +5189,54 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5144,7 +5244,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -5153,7 +5253,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -5168,26 +5268,26 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -5197,19 +5297,19 @@
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/graphql-dgs-spring-graphql-test/dependencies.lock
+++ b/graphql-dgs-spring-graphql-test/dependencies.lock
@@ -12,13 +12,13 @@
             "project": true
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -32,8 +32,11 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-test",
@@ -41,41 +44,41 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -86,19 +89,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-test"
             ]
@@ -109,13 +112,13 @@
             "project": true
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -126,8 +129,11 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-test",
@@ -135,41 +141,41 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -180,19 +186,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-test"
             ]
@@ -256,13 +262,13 @@
             "project": true
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -322,8 +328,11 @@
                 "org.openjdk.jmh:jmh-generator-asm"
             ]
         },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-test",
@@ -331,41 +340,41 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -376,19 +385,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-test"
             ]
@@ -475,47 +484,47 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -523,25 +532,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -571,7 +580,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -579,7 +588,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -625,19 +634,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -645,7 +654,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -702,7 +711,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -710,7 +719,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -720,21 +729,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -742,32 +751,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -843,7 +860,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -852,61 +869,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -919,32 +936,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1463,13 +1480,13 @@
             "project": true
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
@@ -1483,8 +1500,11 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-test",
@@ -1492,41 +1512,41 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -1537,19 +1557,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-test"
             ]
@@ -1585,71 +1605,71 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1673,7 +1693,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -1681,7 +1701,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -1722,19 +1742,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -1757,14 +1777,14 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -1772,21 +1792,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -1795,14 +1815,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -1846,7 +1866,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1855,61 +1875,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1922,32 +1942,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1983,41 +2003,41 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2041,14 +2061,14 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -2088,19 +2108,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -2120,14 +2140,14 @@
             "locked": "26.0.2"
         },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -2135,21 +2155,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -2158,14 +2178,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2203,7 +2223,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2212,61 +2232,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2279,32 +2299,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2340,47 +2360,47 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -2388,25 +2408,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2436,7 +2456,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -2444,7 +2464,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -2478,19 +2498,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -2498,7 +2518,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -2555,7 +2575,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -2563,7 +2583,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -2573,21 +2593,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -2595,32 +2615,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2667,7 +2695,7 @@
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2676,61 +2704,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2743,32 +2771,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/graphql-dgs-spring-graphql/dependencies.lock
+++ b/graphql-dgs-spring-graphql/dependencies.lock
@@ -9,7 +9,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -18,7 +18,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -26,7 +26,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -34,19 +34,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -56,16 +56,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -74,7 +74,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -123,17 +123,17 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6"
+            "locked": "1.15.0"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -141,7 +141,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -150,12 +150,6 @@
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0"
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.20",
@@ -178,40 +172,46 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
+            "locked": "2.0.17"
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5"
+            "locked": "1.4.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -221,7 +221,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -229,7 +229,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -243,57 +243,57 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-webflux",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "compileOnlyDependenciesMetadata": {
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6"
+            "locked": "1.15.0"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -301,7 +301,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "org.springframework:spring-webflux"
             ]
@@ -309,8 +309,8 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0"
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
@@ -322,14 +322,14 @@
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -339,13 +339,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -358,38 +358,38 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-webflux",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -398,7 +398,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -406,7 +406,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -414,19 +414,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -436,7 +436,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -445,7 +445,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -494,20 +494,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql"
@@ -531,39 +531,44 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
+            "locked": "2.0.17"
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5"
+            "locked": "1.4.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -571,14 +576,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -589,19 +594,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "jmh": {
@@ -659,7 +664,7 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -668,7 +673,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -676,7 +681,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -684,19 +689,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -706,16 +711,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -724,7 +729,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -773,17 +778,17 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.14.6"
+            "locked": "1.15.0"
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "org.springframework:spring-context",
@@ -791,7 +796,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -813,12 +818,6 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.20",
             "transitive": [
@@ -838,6 +837,14 @@
             "locked": "26.0.2",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.openjdk.jmh:jmh-core": {
@@ -878,36 +885,34 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
+            "locked": "2.0.17"
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5"
+            "locked": "1.4.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -917,7 +922,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -925,7 +930,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -939,33 +944,33 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-webflux",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -1040,7 +1045,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1049,7 +1054,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -1059,7 +1064,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1070,14 +1075,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1085,7 +1090,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1093,14 +1098,14 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1112,10 +1117,10 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
@@ -1127,7 +1132,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1138,7 +1143,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1220,48 +1225,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1269,25 +1274,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1299,7 +1304,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -1335,7 +1340,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -1343,7 +1348,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -1389,44 +1394,38 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -1434,7 +1433,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -1526,8 +1525,16 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -1535,7 +1542,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -1545,21 +1552,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -1567,32 +1574,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -1650,6 +1665,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -1671,14 +1687,19 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1687,7 +1708,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter",
@@ -1695,7 +1716,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -1704,69 +1725,69 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1776,7 +1797,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -1786,7 +1807,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1802,20 +1823,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -1823,7 +1844,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -1833,22 +1854,22 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2371,7 +2392,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2380,7 +2401,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2388,7 +2409,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2396,14 +2417,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2411,7 +2432,7 @@
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2427,7 +2448,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2437,7 +2458,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2488,13 +2509,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2507,7 +2528,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -2595,6 +2616,13 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.ow2.asm:asm": {
             "locked": "9.7.1",
             "transitive": [
@@ -2605,6 +2633,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -2613,30 +2642,32 @@
             "locked": "2.0.17",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
-                "com.jayway.jsonpath:json-path"
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5"
+            "locked": "1.4.0"
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2644,7 +2675,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -2652,7 +2683,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-aop",
@@ -2663,19 +2694,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ]
@@ -2695,7 +2726,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2704,7 +2735,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -2714,7 +2745,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2725,34 +2756,34 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2764,16 +2795,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -2783,7 +2814,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2863,78 +2894,78 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -2962,7 +2993,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -2970,7 +3001,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -3003,20 +3034,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3030,25 +3061,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -3083,15 +3108,23 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -3099,21 +3132,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -3122,14 +3155,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3156,6 +3189,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -3175,13 +3209,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3190,14 +3223,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -3206,68 +3239,68 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3277,7 +3310,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -3286,7 +3319,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3302,20 +3335,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -3323,7 +3356,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3332,22 +3365,22 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3367,7 +3400,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3376,7 +3409,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -3386,7 +3419,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3397,34 +3430,34 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3436,16 +3469,16 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3455,7 +3488,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3535,48 +3568,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql",
@@ -3604,14 +3637,14 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -3643,20 +3676,20 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3670,25 +3703,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -3720,15 +3747,23 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -3736,21 +3771,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -3759,14 +3794,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3787,6 +3822,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core"
             ]
         },
@@ -3806,13 +3842,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3821,14 +3856,14 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -3837,68 +3872,68 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3908,7 +3943,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.graphql:spring-graphql",
@@ -3917,7 +3952,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3933,20 +3968,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -3954,7 +3989,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3963,22 +3998,22 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -4005,7 +4040,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4014,7 +4049,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
@@ -4024,7 +4059,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -4035,14 +4070,14 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4050,7 +4085,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4058,14 +4093,14 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -4077,10 +4112,10 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
@@ -4092,7 +4127,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4103,7 +4138,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4185,48 +4220,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -4234,25 +4269,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4264,7 +4299,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
@@ -4300,7 +4335,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -4308,7 +4343,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -4342,44 +4377,38 @@
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-core": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
-            "locked": "10.1.40",
+            "locked": "10.1.41",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -4387,7 +4416,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -4479,8 +4508,16 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -4488,7 +4525,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -4498,21 +4535,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -4520,32 +4557,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -4574,6 +4619,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -4595,14 +4641,19 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:dgs-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4611,7 +4662,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter",
@@ -4619,7 +4670,7 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -4628,69 +4679,69 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-json": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.3.5",
+            "locked": "1.4.0",
             "transitive": [
                 "com.netflix.graphql.dgs:dgs-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -4700,7 +4751,7 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
@@ -4710,7 +4761,7 @@
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4726,20 +4777,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test",
@@ -4747,7 +4798,7 @@
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -4757,22 +4808,22 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/graphql-dgs-subscription-types/dependencies.lock
+++ b/graphql-dgs-subscription-types/dependencies.lock
@@ -1,25 +1,25 @@
 {
     "apiDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -31,40 +31,42 @@
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.20"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         }
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -74,13 +76,13 @@
             "project": true
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -95,26 +97,31 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.4",
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -122,13 +129,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -139,48 +146,48 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "implementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -190,13 +197,13 @@
             "project": true
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -208,26 +215,31 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.4",
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -235,13 +247,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -252,25 +264,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "jmh": {
@@ -328,25 +340,25 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -356,13 +368,13 @@
             "project": true
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -387,6 +399,13 @@
             "locked": "26.0.2",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.openjdk.jmh:jmh-core": {
@@ -426,23 +445,21 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -450,13 +467,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -467,25 +484,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -553,7 +570,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -561,27 +578,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -590,13 +607,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -619,48 +636,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -668,25 +685,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -716,7 +733,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -724,7 +741,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -770,19 +787,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -790,7 +807,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -847,8 +864,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -856,7 +880,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -866,21 +890,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -888,32 +912,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -970,7 +1002,8 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.skyscreamer:jsonassert": {
@@ -989,14 +1022,13 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1005,48 +1037,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1054,14 +1086,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1076,41 +1108,41 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1626,25 +1658,25 @@
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1654,13 +1686,13 @@
             "project": true
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1675,26 +1707,31 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
-        "org.reactivestreams:reactive-streams": {
-            "locked": "1.0.4",
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.17"
+        },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1702,13 +1739,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -1719,25 +1756,25 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "testCompileClasspath": {
@@ -1754,7 +1791,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -1762,27 +1799,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1791,13 +1828,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1820,72 +1857,72 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1909,7 +1946,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -1917,7 +1954,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -1958,19 +1995,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -1999,15 +2036,22 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -2015,21 +2059,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -2038,14 +2082,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2071,7 +2115,8 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.skyscreamer:jsonassert": {
@@ -2090,13 +2135,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2105,48 +2149,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2154,14 +2198,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2176,41 +2220,41 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2230,7 +2274,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2238,27 +2282,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2267,13 +2311,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2296,42 +2340,42 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2355,14 +2399,14 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -2402,19 +2446,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -2440,15 +2484,22 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -2456,21 +2507,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -2479,14 +2530,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2506,7 +2557,8 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.skyscreamer:jsonassert": {
@@ -2525,13 +2577,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2540,48 +2591,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2589,14 +2640,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2611,41 +2662,41 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2665,7 +2716,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2673,27 +2724,27 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2702,13 +2753,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2731,48 +2782,48 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -2780,25 +2831,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2828,7 +2879,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -2836,7 +2887,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -2870,19 +2921,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -2890,7 +2941,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -2947,8 +2998,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -2956,7 +3014,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -2966,21 +3024,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -2988,32 +3046,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3041,7 +3107,8 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.skyscreamer:jsonassert": {
@@ -3060,14 +3127,13 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3076,48 +3142,48 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3125,14 +3191,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3147,41 +3213,41 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -1,14 +1,14 @@
 {
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -38,15 +38,17 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         }
@@ -59,7 +61,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -68,7 +70,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -76,7 +78,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -84,19 +86,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -106,10 +108,10 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
@@ -121,7 +123,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -129,7 +131,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -160,13 +162,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
@@ -174,7 +176,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -182,12 +184,6 @@
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1"
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.20",
@@ -248,10 +244,19 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -259,28 +264,27 @@
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17",
             "transitive": [
-                "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader"
+                "com.apollographql.federation:federation-graphql-java-support"
             ]
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.4.5"
+            "locked": "6.5.0"
         },
         "org.springframework.security:spring-security-crypto": {
-            "locked": "6.4.5",
+            "locked": "6.5.0",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -289,13 +293,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -306,53 +310,53 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "compileOnlyDependenciesMetadata": {
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5"
+            "locked": "3.7.6"
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1"
         },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
@@ -364,23 +368,23 @@
             ]
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.4.5"
+            "locked": "6.5.0"
         },
         "org.springframework.security:spring-security-crypto": {
-            "locked": "6.4.5",
+            "locked": "6.5.0",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -388,13 +392,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -404,14 +408,14 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
@@ -425,7 +429,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -434,7 +438,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -442,7 +446,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -450,19 +454,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -478,7 +482,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -486,7 +490,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -517,20 +521,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -598,10 +602,18 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -609,18 +621,17 @@
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17",
             "transitive": [
-                "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader"
+                "com.apollographql.federation:federation-graphql-java-support"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -628,10 +639,10 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -641,19 +652,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "jmh": {
@@ -717,7 +728,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -726,7 +737,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -734,7 +745,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -742,19 +753,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -764,10 +775,10 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8"
+            "locked": "3.2.0"
         },
         "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
+            "locked": "2.36.0",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
@@ -779,7 +790,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -787,7 +798,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -818,13 +829,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
@@ -832,7 +843,7 @@
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -851,12 +862,6 @@
             "locked": "3.6.1",
             "transitive": [
                 "org.openjdk.jmh:jmh-core"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
             ]
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
@@ -918,6 +923,14 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine",
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37",
             "transitive": [
@@ -956,6 +969,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -963,28 +977,27 @@
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17",
             "transitive": [
-                "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader"
+                "com.apollographql.federation:federation-graphql-java-support"
             ]
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.4.5"
+            "locked": "6.5.0"
         },
         "org.springframework.security:spring-security-crypto": {
-            "locked": "6.4.5",
+            "locked": "6.5.0",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -993,13 +1006,13 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -1010,20 +1023,20 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -1097,7 +1110,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1106,7 +1119,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -1114,7 +1127,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -1122,19 +1135,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -1150,7 +1163,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -1165,7 +1178,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1203,13 +1216,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
@@ -1217,35 +1230,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1253,31 +1266,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
@@ -1285,7 +1298,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1315,7 +1328,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -1323,7 +1336,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -1369,19 +1382,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -1389,7 +1402,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -1484,8 +1497,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -1493,7 +1513,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -1503,21 +1523,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -1525,32 +1545,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -1608,6 +1636,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -1629,14 +1658,14 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1645,58 +1674,58 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.4.5"
+            "locked": "6.5.0"
         },
         "org.springframework.security:spring-security-crypto": {
-            "locked": "6.4.5",
+            "locked": "6.5.0",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -1705,14 +1734,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1727,36 +1756,36 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2278,7 +2307,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2287,7 +2316,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2295,7 +2324,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2303,19 +2332,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2331,7 +2360,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -2339,7 +2368,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2370,20 +2399,20 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
@@ -2461,6 +2490,13 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.ow2.asm:asm": {
             "locked": "9.7.1",
             "transitive": [
@@ -2471,6 +2507,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -2479,18 +2516,18 @@
             "locked": "2.0.17",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
-                "com.jayway.jsonpath:json-path"
+                "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2498,10 +2535,10 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -2511,19 +2548,19 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         }
     },
     "testCompileClasspath": {
@@ -2546,7 +2583,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2555,7 +2592,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -2563,7 +2600,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -2571,19 +2608,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -2599,7 +2636,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -2613,7 +2650,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2651,13 +2688,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
@@ -2665,65 +2702,65 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
@@ -2731,7 +2768,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2755,7 +2792,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -2763,7 +2800,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -2804,19 +2841,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -2903,15 +2940,22 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -2919,21 +2963,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -2942,14 +2986,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2976,6 +3020,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -2997,13 +3042,12 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3012,58 +3056,58 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.4.5"
+            "locked": "6.5.0"
         },
         "org.springframework.security:spring-security-crypto": {
-            "locked": "6.4.5",
+            "locked": "6.5.0",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -3072,14 +3116,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3094,36 +3138,36 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3149,7 +3193,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3158,7 +3202,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3166,7 +3210,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -3174,19 +3218,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3202,7 +3246,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
@@ -3216,7 +3260,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3254,13 +3298,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
@@ -3268,35 +3312,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
@@ -3304,7 +3348,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3328,14 +3372,14 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -3375,19 +3419,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -3469,15 +3513,22 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -3485,21 +3536,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -3508,14 +3559,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -3536,6 +3587,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -3557,13 +3609,12 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -3572,58 +3623,58 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.4.5"
+            "locked": "6.5.0"
         },
         "org.springframework.security:spring-security-crypto": {
-            "locked": "6.4.5",
+            "locked": "6.5.0",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -3632,14 +3683,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -3654,36 +3705,36 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -3709,7 +3760,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3718,7 +3769,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
@@ -3726,7 +3777,7 @@
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
@@ -3734,19 +3785,19 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations",
                 "com.fasterxml.jackson.core:jackson-core",
@@ -3762,7 +3813,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -3777,7 +3828,7 @@
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -3815,13 +3866,13 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
@@ -3829,35 +3880,35 @@
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3865,31 +3916,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
@@ -3897,7 +3948,7 @@
             ]
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.7.5",
+            "locked": "3.7.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -3927,7 +3978,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -3935,7 +3986,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -3969,19 +4020,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -3989,7 +4040,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -4084,8 +4135,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -4093,7 +4151,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -4103,21 +4161,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -4125,32 +4183,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -4179,6 +4245,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader",
                 "io.projectreactor:reactor-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
@@ -4200,14 +4267,14 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
+                "com.netflix.graphql.dgs:graphql-error-types",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -4216,58 +4283,58 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.4.5"
+            "locked": "6.5.0"
         },
         "org.springframework.security:spring-security-crypto": {
-            "locked": "6.4.5",
+            "locked": "6.5.0",
             "transitive": [
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
@@ -4276,14 +4343,14 @@
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -4298,36 +4365,36 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.2.6"
+            "locked": "6.2.7"
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsDataLoaderOptionsProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsDataLoaderOptionsProvider.kt
@@ -22,5 +22,5 @@ fun interface DgsDataLoaderOptionsProvider {
     fun getOptions(
         dataLoaderName: String,
         annotation: DgsDataLoader,
-    ): DataLoaderOptions
+    ): DataLoaderOptions.Builder
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDataLoaderOptionsProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDataLoaderOptionsProvider.kt
@@ -24,9 +24,10 @@ class DefaultDataLoaderOptionsProvider : DgsDataLoaderOptionsProvider {
     override fun getOptions(
         dataLoaderName: String,
         annotation: DgsDataLoader,
-    ): DataLoaderOptions {
+    ): DataLoaderOptions.Builder {
         val options =
-            DataLoaderOptions()
+            DataLoaderOptions
+                .newOptions()
                 .setBatchingEnabled(annotation.batching)
                 .setCachingEnabled(annotation.caching)
         if (annotation.maxBatchSize > 0) {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -229,7 +229,7 @@ class DgsDataLoaderProvider(
         }
 
         val extendedBatchLoader = wrappedDataLoader(batchLoader, dataLoaderName, extensionProviders)
-        return DataLoaderFactory.newDataLoader(extendedBatchLoader, options)
+        return DataLoaderFactory.newDataLoader(extendedBatchLoader, options.build())
     }
 
     private fun createDataLoader(
@@ -246,7 +246,7 @@ class DgsDataLoaderProvider(
         }
         val extendedBatchLoader = wrappedDataLoader(batchLoader, dataLoaderName, extensionProviders)
 
-        return DataLoaderFactory.newMappedDataLoader(extendedBatchLoader, options)
+        return DataLoaderFactory.newMappedDataLoader(extendedBatchLoader, options.build())
     }
 
     private fun <T> createDataLoader(
@@ -267,7 +267,7 @@ class DgsDataLoaderProvider(
         }
 
         val extendedBatchLoader = wrappedDataLoader(batchLoader, dataLoaderName, extensionProviders)
-        return DataLoaderFactory.newDataLoader(extendedBatchLoader, options)
+        return DataLoaderFactory.newDataLoader(extendedBatchLoader, options.build())
     }
 
     private fun <T> createDataLoader(
@@ -288,7 +288,7 @@ class DgsDataLoaderProvider(
         }
 
         val extendedBatchLoader = wrappedDataLoader(batchLoader, dataLoaderName, extensionProviders)
-        return DataLoaderFactory.newMappedDataLoader(extendedBatchLoader, options)
+        return DataLoaderFactory.newMappedDataLoader(extendedBatchLoader, options.build())
     }
 
     private fun registerDataLoader(

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/GraphQLJavaErrorInstrumentationTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/GraphQLJavaErrorInstrumentationTest.kt
@@ -167,7 +167,7 @@ class GraphQLJavaErrorInstrumentationTest {
                     .extensions.keys
                     .containsAll(listOf("classification", "errorDetail", "errorType")),
             ).isTrue()
-        Assertions.assertThat(result.errors[0].extensions["classification"]).isEqualTo("OperationNotSupported")
+        Assertions.assertThat(result.errors[0].extensions["classification"]).isEqualTo("ValidationError")
         Assertions.assertThat(result.errors[0].extensions["errorType"]).isEqualTo("BAD_REQUEST")
         Assertions.assertThat(result.errors[0].extensions["errorDetail"]).isEqualTo("INVALID_ARGUMENT")
     }

--- a/graphql-error-types/dependencies.lock
+++ b/graphql-error-types/dependencies.lock
@@ -1,13 +1,13 @@
 {
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -19,40 +19,42 @@
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.20"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
-            ]
-        },
-        "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
+                "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader"
             ]
         }
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -70,28 +72,33 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
+            "locked": "2.0.17"
         }
     },
     "compileOnlyDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
@@ -99,13 +106,13 @@
     },
     "implementationDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -120,17 +127,22 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
+            "locked": "2.0.17"
         }
     },
     "jmh": {
@@ -188,25 +200,25 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.18.3",
+            "locked": "2.19.0",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-annotations"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -234,6 +246,13 @@
             "locked": "26.0.2",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.openjdk.jmh:jmh-core": {
@@ -273,14 +292,12 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
+            "locked": "2.0.17"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -348,13 +365,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -377,47 +394,47 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -425,25 +442,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -473,7 +490,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -481,7 +498,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -527,19 +544,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -547,7 +564,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -603,8 +620,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -612,7 +636,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -622,21 +646,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -644,32 +668,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -726,7 +758,8 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.skyscreamer:jsonassert": {
@@ -745,14 +778,13 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -761,61 +793,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -828,32 +860,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1369,13 +1401,13 @@
     },
     "runtimeClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1393,17 +1425,22 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.17",
-            "transitive": [
-                "com.graphql-java:java-dataloader"
-            ]
+            "locked": "2.0.17"
         }
     },
     "testCompileClasspath": {
@@ -1420,13 +1457,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1449,71 +1486,71 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1537,7 +1574,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -1545,7 +1582,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -1586,19 +1623,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -1620,15 +1657,22 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -1636,21 +1680,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -1659,14 +1703,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -1692,7 +1736,8 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.skyscreamer:jsonassert": {
@@ -1711,13 +1756,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -1726,61 +1770,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -1793,32 +1837,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -1838,13 +1882,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -1867,41 +1911,41 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1925,14 +1969,14 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.assertj:assertj-core",
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -1972,19 +2016,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.springframework.boot:spring-boot-starter-test"
@@ -2003,15 +2047,22 @@
         "org.jetbrains:annotations": {
             "locked": "26.0.2"
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit:junit-bom",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -2019,21 +2070,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
@@ -2042,14 +2093,14 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2069,7 +2120,8 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.skyscreamer:jsonassert": {
@@ -2088,13 +2140,12 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2103,61 +2154,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2170,32 +2221,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
@@ -2215,13 +2266,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.3",
+            "locked": "24.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
-            "locked": "3.3.0",
+            "locked": "5.0.0",
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
@@ -2244,47 +2295,47 @@
             ]
         },
         "io.micrometer:micrometer-commons": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
-            "locked": "1.14.6",
+            "locked": "1.15.0",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.14.0"
+            "locked": "1.14.2"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -2292,25 +2343,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.14.0",
+            "locked": "1.14.2",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2340,7 +2391,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
@@ -2348,7 +2399,7 @@
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.17.5",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.mockito:mockito-core"
@@ -2382,19 +2433,19 @@
             ]
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3",
+            "locked": "3.27.3",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
-            "locked": "4.2.2",
+            "locked": "4.3.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
@@ -2402,7 +2453,7 @@
             ]
         },
         "org.hamcrest:hamcrest-core": {
-            "locked": "2.2",
+            "locked": "3.0",
             "transitive": [
                 "junit:junit"
             ]
@@ -2458,8 +2509,15 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
+            ]
+        },
         "org.junit.jupiter:junit-jupiter": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
@@ -2467,7 +2525,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -2477,21 +2535,21 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
@@ -2499,32 +2557,40 @@
             ]
         },
         "org.junit.platform:junit-platform-engine": {
-            "locked": "1.11.4",
+            "locked": "1.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
+                "org.junit.platform:junit-platform-launcher",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.12.2",
+            "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.11.4",
+            "locked": "5.12.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit.platform:junit-platform-commons",
-                "org.junit.platform:junit-platform-engine"
+                "org.junit.platform:junit-platform-engine",
+                "org.junit.platform:junit-platform-launcher"
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.14.2",
+            "locked": "5.17.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
@@ -2552,7 +2618,8 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java"
+                "com.graphql-java:graphql-java",
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.skyscreamer:jsonassert": {
@@ -2571,14 +2638,13 @@
             "locked": "2.0.17",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
                 "org.apache.logging.log4j:log4j-to-slf4j",
                 "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
                 "org.springframework.boot:spring-boot-starter",
@@ -2587,61 +2653,61 @@
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.4.5"
+            "locked": "3.5.0"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.4.5",
+            "locked": "3.5.0",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-aop": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot",
                 "org.springframework.boot:spring-boot-starter",
@@ -2654,32 +2720,32 @@
             ]
         },
         "org.springframework:spring-expression": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.2.6",
+            "locked": "6.2.7",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
-            "locked": "2.10.0",
+            "locked": "2.10.1",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "2.3",
+            "locked": "2.4",
             "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]

--- a/scripts/test-examples.py
+++ b/scripts/test-examples.py
@@ -114,7 +114,11 @@ def update_build(build_file, version, oss_version):
     file.close()
 
     file_data = find_replace_version(file_data, version)
+    print("after replace version")
+    print(file_data)
     file_data = find_replace_oss_plugin_version(file_data, oss_version)
+    print("after replace oss plugin version")
+    print(file_data)
 
     file = open(build_file, 'w')
     file.write(file_data)

--- a/scripts/test-examples.py
+++ b/scripts/test-examples.py
@@ -100,11 +100,21 @@ def infer_gradle_settings_file(project_dir):
     return file
 
 def infer_spring_boot_version(content):
+    # Pattern to match extra["sb.version"] = "version"
+    # Uses DOTALL flag to handle multiline content and more flexible matching
+    # This handles the exact format in your file: extra["sb.version"] = "3.5.0"
     pattern = r'extra\s*\[\s*["\']sb\.version["\']\s*\]\s*=\s*["\']([^"\']+)["\']'
 
-    match = re.search(pattern, content)
+    match = re.search(pattern, content, re.DOTALL)
     if match:
         return match.group(1)
+
+    # Debug: Let's also try to find any line containing sb.version for troubleshooting
+    debug_pattern = r'.*sb\.version.*'
+    debug_matches = re.findall(debug_pattern, content)
+    if debug_matches:
+        print(f"Debug: Found lines containing 'sb.version': {debug_matches}")
+
     return None
 
 def find_replace_version(content, version):

--- a/scripts/test-examples.py
+++ b/scripts/test-examples.py
@@ -33,7 +33,7 @@ config_file = os.path.abspath(f"{base_path}/config.yml")
 
 examples_path = os.path.abspath(f"{base_path}/../build/examples")
 settings_gradle_kts_template = os.path.abspath(f"{base_path}/settings.gradle.kts")
-root_gradle_kts_file = os.path.abspath(f"{base_path}/build.gradle.kts")
+root_gradle_kts_file = os.path.abspath(f"{base_path}/../build.gradle.kts")
 
 gradle_wd = os.path.abspath(f"{base_path}/..")
 gradlew = os.path.abspath(f"{base_path}/../gradlew")

--- a/scripts/test-examples.py
+++ b/scripts/test-examples.py
@@ -33,6 +33,7 @@ config_file = os.path.abspath(f"{base_path}/config.yml")
 
 examples_path = os.path.abspath(f"{base_path}/../build/examples")
 settings_gradle_kts_template = os.path.abspath(f"{base_path}/settings.gradle.kts")
+root_gradle_kts_file = os.path.abspath(f"{base_path}/build.gradle.kts")
 
 gradle_wd = os.path.abspath(f"{base_path}/..")
 gradlew = os.path.abspath(f"{base_path}/../gradlew")
@@ -44,6 +45,31 @@ def load_config():
     Out.debug(f"Configuration loaded from [{config_file}]:\n{config}\n", State.verbose)
     return config
 
+def load_root_build_file(file_path):
+    print("root build file: " + file_path)
+    file = open(file_path, 'r')
+    file_data = file.read()
+    file.close()
+    return file_data
+
+def infer_spring_boot_version(content):
+    lines = content.split('\n')
+    for line in lines:
+        # Strip all whitespace from the line
+        stripped_line = line.replace(' ', '').replace('\t', '')
+
+        # Check if this line contains our target pattern
+        if 'extra["sb.version"]=' in stripped_line:
+            # Find the equals sign and get everything after it
+            equals_index = stripped_line.find('=')
+            if equals_index != -1:
+                # Get the part after the equals sign
+                value_part = stripped_line[equals_index + 1:]
+                # Remove quotes (both single and double)
+                version = value_part.strip('"').strip("'")
+                return version
+
+    return None
 
 def clone_repos(config, target):
     if not target:
@@ -116,7 +142,8 @@ def update_build(build_file, version, spring_boot_version):
     file.close()
 
     file_data = find_replace_version(file_data, version)
-    file_data = find_replace_oss_plugin_version(file_data, spring_boot_version)
+    if (spring_boot_version is not None):
+        file_data = find_replace_oss_plugin_version(file_data, spring_boot_version)
     print("after version updates")
     print(file_data)
 
@@ -164,7 +191,6 @@ def main(argv):
 
     projects_dir = examples_path
     p_version = ""
-    p_spring_boot_version = "3.5.0" # TODO: Determine this dynamically
     git_clone_projects = False
     keep_project_dir = False
     try:
@@ -209,12 +235,14 @@ def main(argv):
         Out.error(f"No projects available at [{projects_dir}]!")
         exit(2)
 
+    spring_boot_version = infer_spring_boot_version(load_root_build_file(root_gradle_kts_file))
+
     for project in projects:
         project_root = f"{projects_dir}/{project}"
         Out.info(f"Processing project [{project_root}]...")
         build_file = infer_build_file(project_root)
         settings_file = infer_gradle_settings_file(project_root)
-        update_build(build_file, p_version, p_spring_boot_version)
+        update_build(build_file, p_version, spring_boot_version)
         run_example_build(project_root, build_file=build_file, settings_file=settings_file)
 
     if not keep_project_dir:

--- a/scripts/test-examples.py
+++ b/scripts/test-examples.py
@@ -116,7 +116,7 @@ def infer_spring_boot_version(content):
                     version = value_part.strip('"').strip("'")
                     return version
 
-        return None
+    return None
 
 def find_replace_version(content, version):
     regex = re.compile(r"graphql-dgs-platform-dependencies:([0-9\w\-.]+)")

--- a/scripts/test-examples.py
+++ b/scripts/test-examples.py
@@ -104,13 +104,17 @@ def find_replace_version(content, version):
     regex = re.compile(r"graphql-dgs-platform-dependencies:([0-9\w\-.]+)")
     return re.sub(regex, f"graphql-dgs-platform-dependencies:{version}", content)
 
+def find_replace_oss_plugin_version(content, version):
+    regex = re.compile(r'id$"org\.springframework\.boot"$ version "([^"]+)"')
+    return re.sub(regex, f'id("org.springframework.boot") version "{version}"', content)
 
-def update_build(build_file, version):
+def update_build(build_file, version, oss_version):
     file = open(build_file, 'r')
     file_data = file.read()
     file.close()
 
     file_data = find_replace_version(file_data, version)
+    file_data = find_replace_oss_plugin_version(file_data, oss_version)
 
     file = open(build_file, 'w')
     file.write(file_data)
@@ -205,7 +209,7 @@ def main(argv):
         Out.info(f"Processing project [{project_root}]...")
         build_file = infer_build_file(project_root)
         settings_file = infer_gradle_settings_file(project_root)
-        update_build(build_file, p_version)
+        update_build(build_file, p_version, "3.5.0")
         run_example_build(project_root, build_file=build_file, settings_file=settings_file)
 
     if not keep_project_dir:

--- a/scripts/test-examples.py
+++ b/scripts/test-examples.py
@@ -105,8 +105,11 @@ def find_replace_version(content, version):
     return re.sub(regex, f"graphql-dgs-platform-dependencies:{version}", content)
 
 def find_replace_oss_plugin_version(content, version):
-    regex = re.compile(r'id$"org\.springframework\.boot"$ version "([^"]+)"')
-    return re.sub(regex, f'id("org.springframework.boot") version "{version}"', content)
+    pattern = r'(\s*id\s*\(\s*["\']org\.springframework\.boot["\']\s*\)\s*version\s+["\'])[^"\']+(["\'])'
+    replacement = r'\g<1>' + version + r'\g<2>'
+    modified_content = re.sub(pattern, replacement, content)
+
+    return modified_content
 
 def update_build(build_file, version, oss_version):
     file = open(build_file, 'r')
@@ -114,10 +117,8 @@ def update_build(build_file, version, oss_version):
     file.close()
 
     file_data = find_replace_version(file_data, version)
-    print("after replace version")
-    print(file_data)
     file_data = find_replace_oss_plugin_version(file_data, oss_version)
-    print("after replace oss plugin version")
+    print("after version updates")
     print(file_data)
 
     file = open(build_file, 'w')

--- a/scripts/test-examples.py
+++ b/scripts/test-examples.py
@@ -99,6 +99,13 @@ def infer_gradle_settings_file(project_dir):
         file = ""
     return file
 
+def infer_spring_boot_version(content):
+    pattern = r'extra\s*\[\s*["\']sb\.version["\']\s*\]\s*=\s*["\']([^"\']+)["\']'
+
+    match = re.search(pattern, content)
+    if match:
+        return match.group(1)
+    return None
 
 def find_replace_version(content, version):
     regex = re.compile(r"graphql-dgs-platform-dependencies:([0-9\w\-.]+)")
@@ -111,13 +118,15 @@ def find_replace_oss_plugin_version(content, version):
 
     return modified_content
 
-def update_build(build_file, version, oss_version):
+def update_build(build_file, version):
     file = open(build_file, 'r')
     file_data = file.read()
     file.close()
 
+    spring_boot_version = infer_spring_boot_version(file_data)
+    print("using spring boot version " + spring_boot_version)
     file_data = find_replace_version(file_data, version)
-    file_data = find_replace_oss_plugin_version(file_data, oss_version)
+    file_data = find_replace_oss_plugin_version(file_data, spring_boot_version)
     print("after version updates")
     print(file_data)
 
@@ -214,7 +223,7 @@ def main(argv):
         Out.info(f"Processing project [{project_root}]...")
         build_file = infer_build_file(project_root)
         settings_file = infer_gradle_settings_file(project_root)
-        update_build(build_file, p_version, "3.5.0")
+        update_build(build_file, p_version)
         run_example_build(project_root, build_file=build_file, settings_file=settings_file)
 
     if not keep_project_dir:


### PR DESCRIPTION
Upgrade to spring-graphql 1.4.0 and spring-boot 3.5

Pull request checklist
----

- [ X] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ X] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [ X] Make sure the PR doesn't introduce backward compatibility issues
- [ X] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [ X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

This change upgrades to spring boot 3.5 and [spring-graphql 1.4.0](https://github.com/spring-projects/spring-graphql/releases/tag/v1.4.0) and addresses breaking changes: 

Options builder
https://github.com/graphql-java/java-dataloader/releases/tag/v5.0.0

New Strict Mode (We backport to false via property as this breaks our existing test assumptions and could cause downstream issues
https://github.com/graphql-java/graphql-java/commit/09f6a88c36affb1de56b3fe74b2a792b50ed941c



