### PR TITLE
Plumb through user-defined ObjectMapper to be used in both request/response

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomGraphQLClient.kt
@@ -28,20 +28,16 @@ class CustomGraphQLClient(
     private val url: String,
     private val requestExecutor: RequestExecutor,
     private val mapper: ObjectMapper,
-    private val options: GraphQLRequestOptions? = null,
 ) : GraphQLClient {
     constructor(
         url: String,
         requestExecutor: RequestExecutor,
     ) : this(url, requestExecutor, GraphQLRequestOptions.createCustomObjectMapper())
 
-    constructor(url: String, requestExecutor: RequestExecutor, mapper: ObjectMapper) : this(url, requestExecutor, mapper, null)
-
     constructor(url: String, requestExecutor: RequestExecutor, options: GraphQLRequestOptions) : this(
         url,
         requestExecutor,
         GraphQLRequestOptions.createCustomObjectMapper(options),
-        options,
     )
 
     override fun executeQuery(
@@ -64,6 +60,6 @@ class CustomGraphQLClient(
             )
 
         val response = requestExecutor.execute(url, GraphQLClients.defaultHeaders, serializedRequest)
-        return GraphQLClients.handleResponse(response, serializedRequest, url, options)
+        return GraphQLClients.handleResponse(response, serializedRequest, url, mapper)
     }
 }

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomMonoGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomMonoGraphQLClient.kt
@@ -29,20 +29,16 @@ class CustomMonoGraphQLClient(
     private val url: String,
     private val monoRequestExecutor: MonoRequestExecutor,
     private val mapper: ObjectMapper,
-    private val options: GraphQLRequestOptions? = null,
 ) : MonoGraphQLClient {
     constructor(
         url: String,
         monoRequestExecutor: MonoRequestExecutor,
     ) : this (url, monoRequestExecutor, GraphQLRequestOptions.createCustomObjectMapper())
 
-    constructor(url: String, monoRequestExecutor: MonoRequestExecutor, mapper: ObjectMapper) : this(url, monoRequestExecutor, mapper, null)
-
     constructor(url: String, monoRequestExecutor: MonoRequestExecutor, options: GraphQLRequestOptions) : this(
         url,
         monoRequestExecutor,
         GraphQLRequestOptions.createCustomObjectMapper(options),
-        options,
     )
 
     override fun reactiveExecuteQuery(
@@ -64,7 +60,7 @@ class CustomMonoGraphQLClient(
                 GraphQLClients.toRequestMap(query = query, operationName = operationName, variables = variables),
             )
         return monoRequestExecutor.execute(url, GraphQLClients.defaultHeaders, serializedRequest).map { response ->
-            GraphQLClients.handleResponse(response, serializedRequest, url, options)
+            GraphQLClients.handleResponse(response, serializedRequest, url, mapper)
         }
     }
 }

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClients.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClients.kt
@@ -54,6 +54,21 @@ internal object GraphQLClients {
         response: HttpResponse,
         requestBody: String,
         url: String,
+        mapper: ObjectMapper,
+    ): GraphQLResponse {
+        val (statusCode, body) = response
+        val headers = response.headers
+        if (HttpStatusCode.valueOf(response.statusCode).isError) {
+            throw GraphQLClientException(statusCode, url, body ?: "", requestBody)
+        }
+
+        return GraphQLResponse(body ?: "", headers, mapper)
+    }
+
+    fun handleResponse(
+        response: HttpResponse,
+        requestBody: String,
+        url: String,
         options: GraphQLRequestOptions? = null,
     ): GraphQLResponse {
         val (statusCode, body) = response

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphqlSSESubscriptionGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphqlSSESubscriptionGraphQLClient.kt
@@ -65,7 +65,7 @@ class GraphqlSSESubscriptionGraphQLClient(
                 .flatMapMany {
                     val headers = it.headers
                     it.body?.map { serverSentEvent ->
-                        sink.tryEmitNext(GraphQLResponse(json = serverSentEvent, headers = headers, options))
+                        sink.tryEmitNext(GraphQLResponse(json = serverSentEvent, headers = headers, mapper))
                     } ?: Flux.empty()
                 }.onErrorResume {
                     Flux.just(sink.tryEmitError(it))

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/RestClientGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/RestClientGraphQLClient.kt
@@ -42,7 +42,6 @@ class RestClientGraphQLClient(
     private val restClient: RestClient,
     private val headersConsumer: Consumer<HttpHeaders>,
     private val mapper: ObjectMapper,
-    private val options: GraphQLRequestOptions? = null,
 ) : GraphQLClient {
     constructor(restClient: RestClient) : this(restClient, Consumer { })
 
@@ -54,18 +53,10 @@ class RestClientGraphQLClient(
         GraphQLRequestOptions.createCustomObjectMapper(),
     )
 
-    constructor(restClient: RestClient, headersConsumer: Consumer<HttpHeaders>, mapper: ObjectMapper) : this(
-        restClient,
-        headersConsumer,
-        mapper,
-        options = null,
-    )
-
     constructor(restClient: RestClient, options: GraphQLRequestOptions? = null) : this(
         restClient,
         Consumer { },
         GraphQLRequestOptions.createCustomObjectMapper(options),
-        options,
     )
 
     /**
@@ -120,6 +111,6 @@ class RestClientGraphQLClient(
             )
         }
 
-        return GraphQLResponse(json = responseEntity.body ?: "", headers = responseEntity.headers, options)
+        return GraphQLResponse(json = responseEntity.body ?: "", headers = responseEntity.headers, mapper)
     }
 }

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClient.kt
@@ -45,7 +45,6 @@ class WebClientGraphQLClient(
     private val webclient: WebClient,
     private val headersConsumer: Consumer<HttpHeaders>,
     private val mapper: ObjectMapper,
-    private val options: GraphQLRequestOptions? = null,
 ) : MonoGraphQLClient {
     constructor(webclient: WebClient) : this(webclient, Consumer {})
 
@@ -58,22 +57,15 @@ class WebClientGraphQLClient(
     constructor(
         webclient: WebClient,
         options: GraphQLRequestOptions,
-    ) : this(webclient, Consumer {}, GraphQLRequestOptions.createCustomObjectMapper(options), options)
+    ) : this(webclient, Consumer {}, GraphQLRequestOptions.createCustomObjectMapper(options))
 
     constructor(webclient: WebClient, mapper: ObjectMapper) : this(webclient, Consumer {}, mapper)
-
-    constructor(webclient: WebClient, headersConsumer: Consumer<HttpHeaders>, mapper: ObjectMapper) : this(
-        webclient,
-        headersConsumer,
-        mapper,
-        options = null,
-    )
 
     constructor(
         webclient: WebClient,
         headersConsumer: Consumer<HttpHeaders>,
         options: GraphQLRequestOptions,
-    ) : this(webclient, headersConsumer, GraphQLRequestOptions.createCustomObjectMapper(options), options)
+    ) : this(webclient, headersConsumer, GraphQLRequestOptions.createCustomObjectMapper(options))
 
     /**
      * @param query The query string. Note that you can use [code generation](https://netflix.github.io/dgs/generating-code-from-schema/#generating-query-apis-for-external-services) for a type safe query!
@@ -160,7 +152,7 @@ class WebClientGraphQLClient(
             )
         }
 
-        return GraphQLResponse(json = response.body ?: "", headers = response.headers, options)
+        return GraphQLResponse(json = response.body ?: "", headers = response.headers, mapper)
     }
 
     companion object {


### PR DESCRIPTION
A previous change to merge in scalar types into serialization and deserialization missed an edge case where user-provided object mappers to the GQL request, and is clobbered in the GQL response by our generated mapper.  

This change passes the mapper used in the request to the response for Client wrappers.  The Mapper used in the request is either user-defined (which we pass through), or it is created and merged with any provided Scalar implementations, which was the feature added in [2151](https://github.com/Netflix/dgs-framework/pull/2151)

Pull request checklist
----

- [ X] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [ ] Make sure the PR doesn't introduce backward compatibility issues
- [X ] Make sure to have sufficient test cases

Pull Request type
----

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

This is a breaking change to 12.2.0 internal client constructors, but since it was only released yesterday there shouldn't be any usage of it.  I can make it non-breaking but it leaves an unused parameter, so I feel it's better to rip off the bandaid and have a cleaner API.  


