### PR TITLE
Use com.netflix.nebula.netflixoss 11.6.0 to move publishing to Sonatype Central Portal from Sonatype Legacy OSSRH

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
     `java-library`
     id("nebula.dependency-recommender") version "11.0.0"
 
-    id("nebula.netflixoss") version "11.4.0"
+    id("nebula.netflixoss") version "11.6.0"
     id("io.spring.dependency-management") version "1.1.7"
 
     id("org.jmailen.kotlinter") version "5.0.+"


### PR DESCRIPTION
Pull Request type
----

- [x] Build related changes

Changes in this PR
----

Use com.netflix.nebula.netflixoss 11.6.0 to move publishing to Sonatype Central Portal from Sonatype Legacy OSSRH