### PR TITLE
Add a dgs.graphql.strictmode.enabled property

### DIFF
--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
@@ -32,6 +32,7 @@ data class DgsConfigurationProperties(
     val preparsedDocumentProvider: DgsPreparsedDocumentProviderConfigurationProperties =
         DgsPreparsedDocumentProviderConfigurationProperties(),
     val introspection: DgsIntrospectionConfigurationProperties = DgsIntrospectionConfigurationProperties(),
+    val strictmode: DgsStrictModeProperties = DgsStrictModeProperties(),
 ) {
     data class DgsPreparsedDocumentProviderConfigurationProperties(
         val enabled: Boolean = false,
@@ -44,5 +45,9 @@ data class DgsConfigurationProperties(
         /** Due to legacy reasons, SDL comments (i.e. # comments) are shown in introspection queries by default.
          * This property toggles that visibility. */
         val showSdlComments: Boolean = true,
+    )
+
+    data class DgsStrictModeProperties(
+        val enabled: Boolean = true,
     )
 }

--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
@@ -32,7 +32,7 @@ data class DgsConfigurationProperties(
     val preparsedDocumentProvider: DgsPreparsedDocumentProviderConfigurationProperties =
         DgsPreparsedDocumentProviderConfigurationProperties(),
     val introspection: DgsIntrospectionConfigurationProperties = DgsIntrospectionConfigurationProperties(),
-    val strictmode: DgsStrictModeProperties = DgsStrictModeProperties(),
+    val strictMode: DgsStrictModeProperties = DgsStrictModeProperties(),
 ) {
     data class DgsPreparsedDocumentProviderConfigurationProperties(
         val enabled: Boolean = false,

--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
@@ -307,7 +307,7 @@ open class DgsSpringGraphQLAutoConfiguration(
             schemaWiringValidationEnabled = configProps.schemaWiringValidationEnabled,
             enableEntityFetcherCustomScalarParsing = configProps.enableEntityFetcherCustomScalarParsing,
             fallbackTypeResolver = fallbackTypeResolver,
-            enableStrictMode = configProps.strictmode.enabled,
+            enableStrictMode = configProps.strictMode.enabled,
         )
 
     @Bean

--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
@@ -307,6 +307,7 @@ open class DgsSpringGraphQLAutoConfiguration(
             schemaWiringValidationEnabled = configProps.schemaWiringValidationEnabled,
             enableEntityFetcherCustomScalarParsing = configProps.enableEntityFetcherCustomScalarParsing,
             fallbackTypeResolver = fallbackTypeResolver,
+            enableStrictMode = configProps.strictmode.enabled,
         )
 
     @Bean

--- a/graphql-dgs-spring-graphql/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/graphql-dgs-spring-graphql/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -97,6 +97,12 @@
       "description": "Enable async dispatching in the request handling. This can reduce the number of server working threads required, but requires all filters to be async aware, and tests to handle async correctly."
     },
     {
+      "name": "dgs.graphql.strictmode.enabled",
+      "defaultValue": "true",
+      "type": "java.lang.Boolean",
+      "description": "Enable GraphQL Java strict mode on RuntimeWiring.Builder."
+    },
+    {
       "name": "dgs.graphql.virtualthreads.enabled",
       "defaultValue": "false",
       "type": "java.lang.Boolean",

--- a/graphql-dgs-spring-graphql/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/graphql-dgs-spring-graphql/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -97,7 +97,7 @@
       "description": "Enable async dispatching in the request handling. This can reduce the number of server working threads required, but requires all filters to be async aware, and tests to handle async correctly."
     },
     {
-      "name": "dgs.graphql.strictmode.enabled",
+      "name": "dgs.graphql.strict-mode.enabled",
       "defaultValue": "true",
       "type": "java.lang.Boolean",
       "description": "Enable GraphQL Java strict mode on RuntimeWiring.Builder."

--- a/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQlAutoConfigurationTest.kt
+++ b/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQlAutoConfigurationTest.kt
@@ -17,6 +17,7 @@
 package com.netflix.graphql.dgs.springgraphql.autoconfig
 
 import com.netflix.graphql.dgs.DgsQueryExecutor
+import com.netflix.graphql.dgs.autoconfig.DgsConfigurationProperties
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
 import com.netflix.graphql.dgs.mvc.internal.method.HandlerMethodArgumentResolverAdapter
 import com.netflix.graphql.dgs.reactive.DgsReactiveQueryExecutor
@@ -322,6 +323,33 @@ class DgsSpringGraphQlAutoConfigurationTest {
                     assertThat(response.errors.size).isEqualTo(0)
                     assertThat(response.isDataPresent).isTrue()
                 }
+            }
+    }
+
+    @Test
+    fun loadsDefaultStrictmodeConfiguration() {
+        ApplicationContextRunner()
+            .withConfiguration(autoConfigurations)
+            .run { context ->
+                assertThat(
+                    context
+                        .getBean(DgsConfigurationProperties::class.java)
+                        .strictmode.enabled,
+                ).isTrue()
+            }
+    }
+
+    @Test
+    fun loadsStrictmodeConfiguration() {
+        ApplicationContextRunner()
+            .withConfiguration(autoConfigurations)
+            .withPropertyValues("dgs.graphql.strictmode.enabled=false")
+            .run { context ->
+                assertThat(
+                    context
+                        .getBean(DgsConfigurationProperties::class.java)
+                        .strictmode.enabled,
+                ).isFalse()
             }
     }
 }

--- a/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQlAutoConfigurationTest.kt
+++ b/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQlAutoConfigurationTest.kt
@@ -334,7 +334,7 @@ class DgsSpringGraphQlAutoConfigurationTest {
                 assertThat(
                     context
                         .getBean(DgsConfigurationProperties::class.java)
-                        .strictmode.enabled,
+                        .strictMode.enabled,
                 ).isTrue()
             }
     }
@@ -343,12 +343,12 @@ class DgsSpringGraphQlAutoConfigurationTest {
     fun loadsStrictmodeConfiguration() {
         ApplicationContextRunner()
             .withConfiguration(autoConfigurations)
-            .withPropertyValues("dgs.graphql.strictmode.enabled=false")
+            .withPropertyValues("dgs.graphql.strict-mode.enabled=false")
             .run { context ->
                 assertThat(
                     context
                         .getBean(DgsConfigurationProperties::class.java)
-                        .strictmode.enabled,
+                        .strictMode.enabled,
                 ).isFalse()
             }
     }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -112,6 +112,7 @@ class DgsSchemaProvider
         private val schemaWiringValidationEnabled: Boolean = true,
         private val enableEntityFetcherCustomScalarParsing: Boolean = false,
         private val fallbackTypeResolver: TypeResolver? = null,
+        private val enableStrictMode: Boolean = false,
     ) {
         @Suppress("UNUSED_PARAMETER")
         @Deprecated("The mockProviders argument is no longer supported")
@@ -230,7 +231,11 @@ class DgsSchemaProvider
             }
 
             val runtimeWiringBuilder =
-                RuntimeWiring.newRuntimeWiring().codeRegistry(codeRegistryBuilder).fieldVisibility(fieldVisibility)
+                RuntimeWiring
+                    .newRuntimeWiring()
+                    .strictMode(enableStrictMode)
+                    .codeRegistry(codeRegistryBuilder)
+                    .fieldVisibility(fieldVisibility)
 
             val dgsCodeRegistryBuilder =
                 DgsCodeRegistryBuilder(dataFetcherResultProcessors, codeRegistryBuilder, applicationContext)

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -112,7 +112,7 @@ class DgsSchemaProvider
         private val schemaWiringValidationEnabled: Boolean = true,
         private val enableEntityFetcherCustomScalarParsing: Boolean = false,
         private val fallbackTypeResolver: TypeResolver? = null,
-        private val enableStrictMode: Boolean = false,
+        private val enableStrictMode: Boolean = true,
     ) {
         @Suppress("UNUSED_PARAMETER")
         @Deprecated("The mockProviders argument is no longer supported")

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -86,7 +86,7 @@ internal class DgsSchemaProviderTest {
         schemaWiringValidationEnabled: Boolean = true,
         dataFetcherResultProcessors: List<DataFetcherResultProcessor> = emptyList(),
         fallbackTypeResolver: TypeResolver? = null,
-        strictMode: Boolean = false,
+        strictMode: Boolean = true,
     ): DgsSchemaProvider =
         DgsSchemaProvider(
             applicationContext = applicationContext,

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -36,8 +36,11 @@ import graphql.language.TypeName
 import graphql.schema.DataFetcher
 import graphql.schema.FieldCoordinates
 import graphql.schema.GraphQLCodeRegistry
+import graphql.schema.GraphQLScalarType
 import graphql.schema.TypeResolver
+import graphql.schema.idl.RuntimeWiring
 import graphql.schema.idl.TypeDefinitionRegistry
+import graphql.schema.idl.errors.StrictModeWiringException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatNoException
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -83,6 +86,7 @@ internal class DgsSchemaProviderTest {
         schemaWiringValidationEnabled: Boolean = true,
         dataFetcherResultProcessors: List<DataFetcherResultProcessor> = emptyList(),
         fallbackTypeResolver: TypeResolver? = null,
+        strictMode: Boolean = false,
     ): DgsSchemaProvider =
         DgsSchemaProvider(
             applicationContext = applicationContext,
@@ -100,6 +104,7 @@ internal class DgsSchemaProviderTest {
             schemaWiringValidationEnabled = schemaWiringValidationEnabled,
             dataFetcherResultProcessors = dataFetcherResultProcessors,
             fallbackTypeResolver = fallbackTypeResolver,
+            enableStrictMode = strictMode,
         )
 
     @DgsComponent
@@ -1341,6 +1346,49 @@ internal class DgsSchemaProviderTest {
 
             assert(descriptionCommentsInResult.isNotEmpty())
             assert(sdlCommentsInResult.isEmpty())
+        }
+    }
+
+    @Test
+    fun `StrictMode should fail when enabled and duplicate scalars are registered`() {
+        contextRunner.withBeans(DuplicateScalarWiring::class).run { context ->
+            val schemaProvider = schemaProvider(applicationContext = context, strictMode = true)
+            assertThrows<StrictModeWiringException> { schemaProvider.schema() }
+        }
+    }
+
+    @Test
+    fun `StrictMode should not fail when disabled and duplicate scalars are registered`() {
+        contextRunner.withBeans(DuplicateScalarWiring::class).run { context ->
+            val schemaProvider = schemaProvider(applicationContext = context, strictMode = false)
+            assertDoesNotThrow { schemaProvider.schema() }
+        }
+    }
+
+    @DgsComponent
+    class DuplicateScalarWiring {
+        @DgsRuntimeWiring
+        fun customWiring(builder: RuntimeWiring.Builder): RuntimeWiring.Builder {
+            builder.scalar(
+                GraphQLScalarType
+                    .Builder()
+                    .name("Test")
+                    .coercing(LocalDateTimeScalar())
+                    .build(),
+            )
+            return builder
+        }
+
+        @DgsRuntimeWiring
+        fun customWiring2(builder: RuntimeWiring.Builder): RuntimeWiring.Builder {
+            builder.scalar(
+                GraphQLScalarType
+                    .Builder()
+                    .name("Test")
+                    .coercing(LocalDateTimeScalar())
+                    .build(),
+            )
+            return builder
         }
     }
 }


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ x ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Add a property `dgs.graphql.strictmode.enabled` to be able to disable strict mode on the `RuntimeWiring.Builder`.


