### PR TITLE
Correctly rethrow target exception in BatchLoaderWithContextInterceptor when dataloader fails

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/BatchLoaderWithContextInterceptor.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/BatchLoaderWithContextInterceptor.kt
@@ -7,6 +7,7 @@ import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.Timer
 import org.slf4j.LoggerFactory
 import java.lang.reflect.InvocationHandler
+import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 import java.util.concurrent.CompletionStage
 
@@ -50,6 +51,8 @@ internal class BatchLoaderWithContextInterceptor(
                             ).register(registry),
                     )
                 }
+            } catch (exception: InvocationTargetException) {
+                throw exception.targetException
             } catch (exception: Exception) {
                 logger.warn("Error creating timer interceptor '{}' for {} with exception {}", ID, javaClass.simpleName, exception.message)
                 @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION

Pull Request type
----

- [x ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

The `BatchLoaderWithContextInterceptor` tracks how much time is spent in a dataloader. The error handling of this interceptor would also catch exceptions happening in the dataloader, which is incorrect and leads to the exception being wrapped in an `InvocationTargetException`.
With this PR it will correctly rethrow the `targetException`,