### PR TITLE
Allow strict mode with `@DgsRuntimeWiring`

### DIFF
--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -1365,6 +1365,15 @@ internal class DgsSchemaProviderTest {
         }
     }
 
+    @Test
+    fun `StrictMode should not fail when enabled and @DgsRuntimeWiring registers type resolver`() {
+        val locations = listOf("classpath:union/union.graphqls")
+        contextRunner.withBeans(RegisterTypeResolverWithRuntimeWiring::class).run { context ->
+            val schemaProvider = schemaProvider(applicationContext = context, schemaLocations = locations, strictMode = true)
+            assertDoesNotThrow { schemaProvider.schema() }
+        }
+    }
+
     @DgsComponent
     class DuplicateScalarWiring {
         @DgsRuntimeWiring
@@ -1388,6 +1397,24 @@ internal class DgsSchemaProviderTest {
                     .coercing(LocalDateTimeScalar())
                     .build(),
             )
+            return builder
+        }
+    }
+
+    @DgsComponent
+    class RegisterTypeResolverWithRuntimeWiring {
+        @DgsRuntimeWiring
+        fun customWiring(builder: RuntimeWiring.Builder): RuntimeWiring.Builder {
+            builder.type("RequestType") { type ->
+                type.typeResolver { env ->
+                    env.schema.getObjectType("RequestType")
+                }
+            }
+            builder.type("ResultType") { type ->
+                type.typeResolver { env ->
+                    env.schema.getObjectType("ResultType")
+                }
+            }
             return builder
         }
     }

--- a/graphql-dgs/src/test/resources/union/union.graphqls
+++ b/graphql-dgs/src/test/resources/union/union.graphqls
@@ -1,0 +1,33 @@
+interface RequestType {
+    name: String
+}
+
+type RequestType1 implements RequestType {
+    name: String
+    description: String
+}
+
+type RequestType2 implements RequestType {
+    name: String
+    flag: Boolean
+}
+
+type ResultType1 {
+    message: String
+}
+
+type ResultType2 {
+    code: String
+    description: String
+}
+
+type ResultType3 {
+    message: String
+    code: String
+    flag: Boolean
+}
+
+union ResultType =
+    ResultType1 |
+    ResultType2 |
+    ResultType3


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

* Invoke `checkTypeResolverExists()` after `@DgsRuntimeWiring` to allow strict mode to be enabled with type resolvers registered via `@DgsRuntimeWiring`

Prior to this PR, enabling strict mode (`dgs.graphql.strict-mode.enabled=true`) could cause failures if applications use the `RuntimeWiring.Builder` to register type resolvers in methods annotated with `@DgsRuntimeWiring`. This PR moves the logic in `DgsSchemaProvider` to only automatically register type resolvers for interface and union types after callbacks to user code (`@DgsScalar`, `@DgsDirective`, `@DgsData`, `@DgsTypeResolver`, `@DgsCodeRegistry`, but mainly `@DgsRuntimeWiring`).

This allows applications to register custom type resolvers for interface and union types with strict mode enabled, as in the following example:

```java
@DgsComponent
public class MyRuntimeWiring {
    @DgsRuntimeWiring
    public RuntimeWiring.Builder runtimeWiring(RuntimeWiring.Builder builder) {
        builder.type("MyInterfaceType", type -> type.typeResolver(new MyInterfaceTypeResolver()));
        builder.type("MyUnionType", type -> type.typeResolver(new MyUnionTypeResolver()));
        return builder;
    }
}
```

Closes gh-2180