### PR TITLE
Allow `@Source` resolution for interface types

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/SourceArgumentResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/SourceArgumentResolver.kt
@@ -32,7 +32,7 @@ class SourceArgumentResolver : ArgumentResolver {
             throw IllegalArgumentException("Source is null. Are you trying to use @Source on a root field (e.g. @DgsQuery)?")
         }
 
-        if (parameter.parameterType == source.javaClass) {
+        if (parameter.parameterType.isAssignableFrom(source.javaClass)) {
             return source
         } else {
             throw IllegalArgumentException(

--- a/graphql-dgs/src/test/resources/source-argument-test/schema.graphqls
+++ b/graphql-dgs/src/test/resources/source-argument-test/schema.graphqls
@@ -1,8 +1,14 @@
 type Query {
     shows: [Show]
+    movies: [Movie]
 }
 
 type Show {
+    title: String
+    description: String
+}
+
+type Movie {
     title: String
     description: String
 }


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

**Make the `@Source` attribute more robust by allowing to be bound to an interface / abstract class parameter.**

- Updated `SourceArgumentResolver` to support assigning interface types by using `isAssignableFrom`.
- Added test cases for handling `@Source` with interface types.
- Extended GraphQL schema and test data to include `Movie` and `Entertainment` examples.

**This PR solves the following problem:**

Given a schema like this:

```graphql
interface A {
   foo: String
}

type B extends A {
   foo: String
}

type C extends A {
   foo: String
}
```

Allows us to have a resolver using `DgsDataFetchingEnvironment` like this:

```java
  @DgsData(parentType = "B", field = "foo")
  @DgsData(parentType = "C", field = "foo")
  public String getFoo(DgsDataFetchingEnvironment dfe) {
    return service.resolve(a);
  }
```

But the implementation with `@Source` crashed with error: `Invalid source type 'B'. Expected type 'A'`. Regardless, that B is assignable to A.

```java
  @DgsData(parentType = "B", field = "foo")
  @DgsData(parentType = "C", field = "foo")
  public String getFoo(@Source A a) {
    A a = dfe.getSource();
    return service.resolve(a);
  }
```

Alternatives considered
----

- One resolver for each type -> bloating code.
- Sticking with `dfe.getSource()` -> boiler code.