### PR TITLE
Fix: Properly construct a dgsDataLoaderReloadController

### DIFF
--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
@@ -257,12 +257,11 @@ open class DgsSpringGraphQLAutoConfiguration(
         /**
          * Creates a [ReloadableDgsDataLoaderProvider] that wraps the standard [DgsDataLoaderProvider].
          *
-         * This provider supports dynamic reloading of data loaders based on the [DgsReloadDataLoadersIndicator].
+         * This provider supports dynamic reloading of data loaders based on the [DgsDataLoaderReloadController].
          * It maintains the same interface as the standard provider but adds reload capabilities.
          *
          * The `@Primary` annotation ensures this bean takes precedence over the standard `DgsDataLoaderProvider`
          * when reload functionality is enabled.
-         *
          */
         @Bean
         @Primary
@@ -272,7 +271,7 @@ open class DgsSpringGraphQLAutoConfiguration(
             @Qualifier("dgsScheduledExecutorService") dgsScheduledExecutorService: ScheduledExecutorService,
             extensionProviders: List<DataLoaderInstrumentationExtensionProvider>,
             customizers: List<DgsDataLoaderCustomizer>,
-        ): DgsDataLoaderProvider {
+        ): ReloadableDgsDataLoaderProvider {
             LOG.info("Creating reloadable data loader provider with reload support enabled")
             return ReloadableDgsDataLoaderProvider(
                 applicationContext = applicationContext,

--- a/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQlAutoConfigurationTest.kt
+++ b/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQlAutoConfigurationTest.kt
@@ -16,9 +16,13 @@
 
 package com.netflix.graphql.dgs.springgraphql.autoconfig
 
+import com.netflix.graphql.dgs.DgsDataLoaderReloadController
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.dgs.autoconfig.DgsConfigurationProperties
+import com.netflix.graphql.dgs.internal.DefaultDgsDataLoaderProvider
+import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
+import com.netflix.graphql.dgs.internal.ReloadableDgsDataLoaderProvider
 import com.netflix.graphql.dgs.mvc.internal.method.HandlerMethodArgumentResolverAdapter
 import com.netflix.graphql.dgs.reactive.DgsReactiveQueryExecutor
 import com.netflix.graphql.dgs.reactive.internal.DefaultDgsReactiveGraphQLContextBuilder
@@ -176,6 +180,44 @@ class DgsSpringGraphQlAutoConfigurationTest {
                         .getBean(DgsSpringGraphQLConfigurationProperties::class.java)
                         .webmvc.asyncdispatch.enabled,
                 ).isFalse()
+            }
+    }
+
+    @Test
+    fun supportsReloadableDataLoaders() {
+        // when dgs reload is disabled
+        ApplicationContextRunner()
+            .withConfiguration(autoConfigurations)
+            .withPropertyValues("dgs.reload=false")
+            .run { context ->
+                assertThat(context)
+                    .doesNotHaveBean(DgsSpringGraphQLAutoConfiguration.DgsDataLoaderReloadAutoConfiguration::class.java)
+                assertThat(context)
+                    .doesNotHaveBean(ReloadableDgsDataLoaderProvider::class.java)
+                assertThat(context)
+                    .doesNotHaveBean(DgsDataLoaderReloadController::class.java)
+                assertThat(context)
+                    .getBean(DgsDataLoaderProvider::class.java)
+                    .describedAs { "The primary DgsDataLoaderProvider " }
+                    .isNotNull
+                    .isInstanceOf(DefaultDgsDataLoaderProvider::class.java)
+            }
+        // when dgs reload is enabled
+        ApplicationContextRunner()
+            .withConfiguration(autoConfigurations)
+            .withPropertyValues("dgs.reload=true")
+            .run { context ->
+                assertThat(context)
+                    .hasSingleBean(DgsSpringGraphQLAutoConfiguration.DgsDataLoaderReloadAutoConfiguration::class.java)
+                assertThat(context)
+                    .hasSingleBean(ReloadableDgsDataLoaderProvider::class.java)
+                assertThat(context)
+                    .hasSingleBean(DgsDataLoaderReloadController::class.java)
+                assertThat(context)
+                    .getBean(DgsDataLoaderProvider::class.java)
+                    .describedAs { "The primary DgsDataLoaderProvider " }
+                    .isNotNull
+                    .isInstanceOf(ReloadableDgsDataLoaderProvider::class.java)
             }
     }
 


### PR DESCRIPTION
Pull request checklist
----

- [X] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [X] Make sure the PR doesn't introduce backward compatibility issues
- [X] Make sure to have sufficient test cases

Pull Request type
----

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

The `reloadableDgsDataLoaderProvider` must return an instance of `ReloadableDgsDataLoaderProvider` instead of the more generic `DgsDataLoaderProvider` such that the `dgsDataLoaderReloadController` can be constructed.

This commit addresses the issue above as well as adds tests to confirm the beans are available, or not, with and without the `dgs.reload` flag enabled.