### PR TITLE
Update package names of excluded autoconfigs for SB4

### DIFF
--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/ExcludeAutoConfigurationsEnvironmentPostProcessor.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/ExcludeAutoConfigurationsEnvironmentPostProcessor.kt
@@ -82,11 +82,11 @@ class ExcludeAutoConfigurationsEnvironmentPostProcessor : EnvironmentPostProcess
             mapOf(
                 Pair(
                     "dgs.springgraphql.autoconfiguration.graphqlobservation.enabled",
-                    "org.springframework.boot.actuate.autoconfigure.observation.graphql.GraphQlObservationAutoConfiguration",
+                    "org.springframework.boot.graphql.autoconfigure.observation.GraphQlObservationAutoConfiguration",
                 ),
                 Pair(
                     "dgs.springgraphql.autoconfiguration.graphqlwebmvcsecurity.enabled",
-                    "org.springframework.boot.autoconfigure.graphql.security.GraphQlWebMvcSecurityAutoConfiguration",
+                    "org.springframework.boot.graphql.autoconfigure.security.GraphQlWebMvcSecurityAutoConfiguration",
                 ),
             )
 

--- a/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/ExcludeAutoConfigurationsEnvironmentPostProcessorTest.kt
+++ b/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/ExcludeAutoConfigurationsEnvironmentPostProcessorTest.kt
@@ -14,8 +14,8 @@ class ExcludeAutoConfigurationsEnvironmentPostProcessorTest {
         assertThat(
             env.getProperty("spring.autoconfigure.exclude"),
         ).contains(
-            "org.springframework.boot.actuate.autoconfigure.observation.graphql.GraphQlObservationAutoConfiguration",
-            "org.springframework.boot.autoconfigure.graphql.security.GraphQlWebMvcSecurityAutoConfiguration",
+            "org.springframework.boot.graphql.autoconfigure.observation.GraphQlObservationAutoConfiguration",
+            "org.springframework.boot.graphql.autoconfigure.security.GraphQlWebMvcSecurityAutoConfiguration",
         )
     }
 
@@ -31,8 +31,8 @@ class ExcludeAutoConfigurationsEnvironmentPostProcessorTest {
 
         ExcludeAutoConfigurationsEnvironmentPostProcessor().postProcessEnvironment(env, SpringApplication())
         assertThat(env.getProperty("spring.autoconfigure.exclude"))
-            .contains("org.springframework.boot.actuate.autoconfigure.observation.graphql.GraphQlObservationAutoConfiguration")
-            .doesNotContain("org.springframework.boot.autoconfigure.graphql.security.GraphQlWebMvcSecurityAutoConfiguration")
+            .contains("org.springframework.boot.graphql.autoconfigure.observation.GraphQlObservationAutoConfiguration")
+            .doesNotContain("org.springframework.boot.graphql.autoconfigure.security.GraphQlWebMvcSecurityAutoConfiguration")
     }
 
     @Test
@@ -44,8 +44,8 @@ class ExcludeAutoConfigurationsEnvironmentPostProcessorTest {
 
         ExcludeAutoConfigurationsEnvironmentPostProcessor().postProcessEnvironment(env, SpringApplication())
         assertThat(env.getProperty("spring.autoconfigure.exclude"))
-            .contains("org.springframework.boot.autoconfigure.graphql.security.GraphQlWebMvcSecurityAutoConfiguration")
-            .doesNotContain("org.springframework.boot.actuate.autoconfigure.observation.graphql.GraphQlObservationAutoConfiguration")
+            .contains("org.springframework.boot.graphql.autoconfigure.security.GraphQlWebMvcSecurityAutoConfiguration")
+            .doesNotContain("org.springframework.boot.graphql.autoconfigure.observation.GraphQlObservationAutoConfiguration")
     }
 
     @Test
@@ -57,8 +57,8 @@ class ExcludeAutoConfigurationsEnvironmentPostProcessorTest {
         assertThat(env.getProperty("spring.autoconfigure.exclude"))
             .contains(
                 "someexclude",
-                "org.springframework.boot.actuate.autoconfigure.observation.graphql.GraphQlObservationAutoConfiguration",
-                "org.springframework.boot.autoconfigure.graphql.security.GraphQlWebMvcSecurityAutoConfiguration",
+                "org.springframework.boot.graphql.autoconfigure.observation.GraphQlObservationAutoConfiguration",
+                "org.springframework.boot.graphql.autoconfigure.security.GraphQlWebMvcSecurityAutoConfiguration",
             )
     }
 
@@ -74,8 +74,8 @@ class ExcludeAutoConfigurationsEnvironmentPostProcessorTest {
         assertThat(env.getProperty("spring.autoconfigure.exclude"))
             .contains(
                 "someotherexclude",
-                "org.springframework.boot.actuate.autoconfigure.observation.graphql.GraphQlObservationAutoConfiguration",
-                "org.springframework.boot.autoconfigure.graphql.security.GraphQlWebMvcSecurityAutoConfiguration",
+                "org.springframework.boot.graphql.autoconfigure.observation.GraphQlObservationAutoConfiguration",
+                "org.springframework.boot.graphql.autoconfigure.security.GraphQlWebMvcSecurityAutoConfiguration",
             )
 
         assertThat(env.getProperty("spring.autoconfigure.exclude"))


### PR DESCRIPTION
These autoconfigs moved from `spring-boot-autoconfigure` to the `spring-boot-graphql` module, example:

Old: https://github.com/spring-projects/spring-boot/blob/v3.5.6/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/security/GraphQlWebMvcSecurityAutoConfiguration.java
New: https://github.com/spring-projects/spring-boot/blob/main/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/security/GraphQlWebMvcSecurityAutoConfiguration.java