### PR TITLE
Use concrete DefaultDgsDataLoaderProvider type in @bean definition for AOT to detect correctly.

### DIFF
--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
@@ -229,7 +229,7 @@ open class DgsSpringGraphQLAutoConfiguration(
         @Qualifier("dgsScheduledExecutorService") dgsScheduledExecutorService: ScheduledExecutorService,
         extensionProviders: List<DataLoaderInstrumentationExtensionProvider>,
         customizers: List<DgsDataLoaderCustomizer>,
-    ): DgsDataLoaderProvider =
+    ): DefaultDgsDataLoaderProvider =
         DefaultDgsDataLoaderProvider(
             applicationContext = applicationContext,
             extensionProviders = extensionProviders,


### PR DESCRIPTION
Fix for #2237