### PR TITLE
feat: migrate from Jackson 2 to Jackson 3 (tools.jackson) for Spring Boot 4 native support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,9 @@ allprojects {
     // as dependencies. e.g. KOTLIN_VERSION
     extra["sb.version"] = "4.0.0"
     extra["kotlin.version"] = Versions.KOTLIN_VERSION
+    // Override Spring Boot's json-path 2.9.0 with 3.0.0 which ships
+    // Jackson3JsonProvider/Jackson3MappingProvider for the Jackson 3 migration.
+    extra["json-path.version"] = "3.0.0"
 }
 val internalBomModules by extra(
     listOf(

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -113,21 +113,123 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.intellij.deps:trove4j": {
+            "locked": "1.0.20200330"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.6.10"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.1.0"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.6.4"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.1.0"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.intellij.deps:trove4j": {
+            "locked": "1.0.20200330"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.6.10"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.1.0"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.6.4"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {

--- a/dgs-starter-test/dependencies.lock
+++ b/dgs-starter-test/dependencies.lock
@@ -36,7 +36,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -62,7 +62,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -119,7 +119,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -154,7 +154,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -183,7 +183,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "firstLevelTransitive": [
@@ -195,7 +195,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -311,21 +311,117 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
@@ -348,7 +444,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -406,7 +502,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "firstLevelTransitive": [
@@ -415,7 +511,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -444,7 +540,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "firstLevelTransitive": [
@@ -453,7 +549,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -482,7 +578,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "firstLevelTransitive": [
@@ -494,7 +590,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"

--- a/dgs-starter/dependencies.lock
+++ b/dgs-starter/dependencies.lock
@@ -15,12 +15,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -97,12 +103,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -160,7 +172,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -185,12 +197,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -248,7 +266,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -284,12 +302,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -366,12 +390,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -429,7 +459,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -463,12 +493,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -526,7 +562,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -558,35 +594,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -596,12 +603,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -653,7 +666,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -687,7 +700,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -706,7 +720,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -777,6 +791,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     },
     "kotlinBouncyCastleConfiguration": {
@@ -832,21 +855,117 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
@@ -863,35 +982,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -901,12 +991,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -989,7 +1085,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -1008,7 +1105,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -1058,6 +1155,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     },
     "swiftExportClasspathResolvable": {
@@ -1081,11 +1187,18 @@
             ],
             "locked": "25.0"
         },
-        "com.jayway.jsonpath:json-path": {
+        "com.graphql-java:java-dataloader": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "6.0.0"
+        },
+        "com.jayway.jsonpath:json-path": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client"
+            ],
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -1126,7 +1239,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1146,7 +1259,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1180,11 +1293,18 @@
             ],
             "locked": "25.0"
         },
-        "com.jayway.jsonpath:json-path": {
+        "com.graphql-java:java-dataloader": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "6.0.0"
+        },
+        "com.jayway.jsonpath:json-path": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client"
+            ],
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -1225,7 +1345,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1245,7 +1365,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1277,35 +1397,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1315,12 +1406,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -1372,7 +1469,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -1406,7 +1503,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -1425,7 +1523,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1487,6 +1585,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     }
 }

--- a/graphql-dgs-client/build.gradle.kts
+++ b/graphql-dgs-client/build.gradle.kts
@@ -23,10 +23,7 @@ dependencies {
     compileOnly("org.springframework:spring-webflux")
 
     implementation("org.springframework:spring-web")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
-    implementation("com.fasterxml.jackson.module:jackson-module-parameter-names")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
+    implementation("tools.jackson.module:jackson-module-kotlin")
     implementation("com.graphql-java:graphql-java")
 
     implementation("org.jetbrains:annotations:26.1.0")

--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -13,7 +13,7 @@
             "locked": "25.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -41,18 +41,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
@@ -60,7 +48,7 @@
             "locked": "25.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -81,7 +69,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -91,6 +79,9 @@
         },
         "org.springframework:spring-webflux": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "compileOnlyDependenciesMetadata": {
@@ -105,18 +96,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
@@ -124,7 +103,7 @@
             "locked": "25.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -145,13 +124,16 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
         },
         "org.springframework:spring-web": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "jmh": {
@@ -179,7 +161,7 @@
             "locked": "25.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -207,18 +189,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
@@ -226,7 +196,7 @@
             "locked": "25.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -247,7 +217,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -266,6 +236,9 @@
         },
         "org.springframework:spring-webflux": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "jmhCompileOnlyDependenciesMetadata": {
@@ -280,18 +253,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
@@ -299,7 +260,7 @@
             "locked": "25.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -320,7 +281,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -336,6 +297,9 @@
         },
         "org.springframework:spring-web": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "jmhRuntimeClasspath": {
@@ -351,35 +315,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "2.20"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -404,7 +339,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -420,7 +355,8 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "project": true
         },
@@ -492,7 +428,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -534,7 +470,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -558,7 +495,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -670,6 +607,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     },
     "kotlinBouncyCastleConfiguration": {
@@ -725,21 +671,117 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
@@ -749,18 +791,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
@@ -768,7 +798,7 @@
             "locked": "25.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -792,7 +822,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -808,6 +838,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "swiftExportClasspathResolvable": {
@@ -823,18 +856,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -857,7 +878,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -937,7 +958,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -965,7 +986,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1002,6 +1023,9 @@
         },
         "org.springframework:spring-web": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "testImplementationDependenciesMetadata": {
@@ -1012,18 +1036,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1046,7 +1058,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1126,7 +1138,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1154,7 +1166,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1191,6 +1203,9 @@
         },
         "org.springframework:spring-web": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "testRuntimeClasspath": {
@@ -1207,35 +1222,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1259,7 +1245,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1275,7 +1261,8 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "project": true
         },
@@ -1347,7 +1334,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -1389,7 +1376,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -1413,7 +1401,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1516,6 +1504,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     }
 }

--- a/graphql-dgs-client/src/main/java/module-info.java
+++ b/graphql-dgs-client/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 module com.netflix.graphql.dgs.client {
     requires kotlin.stdlib;
-    requires com.fasterxml.jackson.databind;
+    requires tools.jackson.databind;
+    requires com.fasterxml.jackson.annotation;
     requires org.jetbrains.annotations;
     requires spring.web;
 

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomGraphQLClient.kt
@@ -16,8 +16,8 @@
 
 package com.netflix.graphql.dgs.client
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.intellij.lang.annotations.Language
+import tools.jackson.databind.json.JsonMapper
 
 /**
  * Blocking implementation of a GraphQL client.
@@ -27,7 +27,7 @@ import org.intellij.lang.annotations.Language
 class CustomGraphQLClient(
     private val url: String,
     private val requestExecutor: RequestExecutor,
-    private val mapper: ObjectMapper,
+    private val mapper: JsonMapper,
 ) : GraphQLClient {
     constructor(
         url: String,

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomMonoGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomMonoGraphQLClient.kt
@@ -16,9 +16,9 @@
 
 package com.netflix.graphql.dgs.client
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.intellij.lang.annotations.Language
 import reactor.core.publisher.Mono
+import tools.jackson.databind.json.JsonMapper
 
 /**
  * Non-blocking implementation of a GraphQL client, based on the [Mono] type.
@@ -28,7 +28,7 @@ import reactor.core.publisher.Mono
 class CustomMonoGraphQLClient(
     private val url: String,
     private val monoRequestExecutor: MonoRequestExecutor,
-    private val mapper: ObjectMapper,
+    private val mapper: JsonMapper,
 ) : MonoGraphQLClient {
     constructor(
         url: String,

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
@@ -16,8 +16,8 @@
 
 package com.netflix.graphql.dgs.client
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.intellij.lang.annotations.Language
+import tools.jackson.databind.json.JsonMapper
 
 /**
  * GraphQL client interface for blocking clients.
@@ -88,7 +88,7 @@ interface GraphQLClient {
         fun createCustom(
             url: String,
             requestExecutor: RequestExecutor,
-            mapper: ObjectMapper,
+            mapper: JsonMapper,
         ) = CustomGraphQLClient(url, requestExecutor, mapper)
 
         @JvmStatic

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClients.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClients.kt
@@ -16,19 +16,18 @@
 
 package com.netflix.graphql.dgs.client
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.KotlinFeature
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.MediaType
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinFeature
+import tools.jackson.module.kotlin.KotlinModule
 
 internal object GraphQLClients {
     @Deprecated(message = "Use GraphQLRequestOptions.createCustomObjectMapper instead")
-    internal val objectMapper: ObjectMapper =
-        Jackson2ObjectMapperBuilder
-            .json()
-            .modulesToInstall(
+    internal val objectMapper: JsonMapper =
+        JsonMapper
+            .builder()
+            .addModule(
                 KotlinModule
                     .Builder()
                     .enable(KotlinFeature.NullIsSameAsDefault)
@@ -51,7 +50,7 @@ internal object GraphQLClients {
         response: HttpResponse,
         requestBody: String,
         url: String,
-        mapper: ObjectMapper,
+        mapper: JsonMapper,
     ): GraphQLResponse {
         val statusCode = response.statusCode
         val body = response.body

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLRequestOptions.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLRequestOptions.kt
@@ -16,23 +16,20 @@
 
 package com.netflix.graphql.dgs.client
 
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.JsonSerializer
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.KotlinFeature
-import com.fasterxml.jackson.module.kotlin.kotlinModule
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
 import graphql.GraphQLContext
 import graphql.schema.Coercing
+import tools.jackson.core.JsonGenerator
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.SerializationContext
+import tools.jackson.databind.ValueDeserializer
+import tools.jackson.databind.ValueSerializer
+import tools.jackson.databind.cfg.EnumFeature
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.databind.module.SimpleModule
+import tools.jackson.module.kotlin.KotlinFeature
+import tools.jackson.module.kotlin.kotlinModule
 import java.util.Locale
 
 /**
@@ -53,7 +50,7 @@ class GraphQLRequestOptions(
     class CustomScalarDeserializer<T>(
         private val coercing: Coercing<*, *>,
         private val graphQLContext: GraphQLContext,
-    ) : JsonDeserializer<T>() {
+    ) : ValueDeserializer<T>() {
         @Suppress("UNCHECKED_CAST")
         override fun deserialize(
             p: JsonParser,
@@ -65,16 +62,16 @@ class GraphQLRequestOptions(
     }
 
     /**
-     * Helper class to wrap a scalar serialization into a Jackson JsonSerializer
+     * Helper class to wrap a scalar serialization into a Jackson ValueSerializer
      */
     class CustomScalarSerializer<T>(
         private val coercing: Coercing<*, *>,
         private val graphQLContext: GraphQLContext,
-    ) : JsonSerializer<T>() {
+    ) : ValueSerializer<T>() {
         override fun serialize(
             value: T,
             gen: JsonGenerator,
-            serializers: SerializerProvider,
+            ctxt: SerializationContext,
         ) {
             val serializedValue = coercing.serialize(value as Any, graphQLContext, Locale.getDefault())
             gen.writeString(serializedValue.toString())
@@ -82,13 +79,10 @@ class GraphQLRequestOptions(
     }
 
     companion object {
-        fun createCustomObjectMapper(options: GraphQLRequestOptions? = null): ObjectMapper {
-            val mapper = ObjectMapper()
-            mapper.registerModule(kotlinModule { enable(KotlinFeature.NullIsSameAsDefault) })
-            mapper.registerModule(JavaTimeModule())
-            mapper.registerModule(ParameterNamesModule())
-            mapper.registerModule(Jdk8Module())
-            mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+        fun createCustomObjectMapper(options: GraphQLRequestOptions? = null): JsonMapper {
+            val builder = JsonMapper.builder()
+            builder.addModule(kotlinModule { enable(KotlinFeature.NullIsSameAsDefault) })
+            builder.enable(EnumFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
 
             // Register custom deserializers if scalars are provided
             options?.scalars?.forEach { (clazz, coercing) ->
@@ -104,13 +98,13 @@ class GraphQLRequestOptions(
                         options.graphQLContext,
                     ),
                 )
-                mapper.registerModule(module)
+                builder.addModule(module)
             }
-            return mapper
+            return builder.build()
         }
 
         // Overloaded method for Java compatibility
         @JvmStatic
-        fun createCustomObjectMapper(): ObjectMapper = createCustomObjectMapper(null)
+        fun createCustomObjectMapper(): JsonMapper = createCustomObjectMapper(null)
     }
 }

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
@@ -17,25 +17,22 @@
 package com.netflix.graphql.dgs.client
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.KotlinFeature
-import com.fasterxml.jackson.module.kotlin.jsonMapper
-import com.fasterxml.jackson.module.kotlin.kotlinModule
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
 import com.jayway.jsonpath.Configuration
 import com.jayway.jsonpath.DocumentContext
 import com.jayway.jsonpath.JsonPath
 import com.jayway.jsonpath.Option
 import com.jayway.jsonpath.TypeRef
-import com.jayway.jsonpath.spi.json.JacksonJsonProvider
-import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider
+import com.jayway.jsonpath.spi.json.Jackson3JsonProvider
+import com.jayway.jsonpath.spi.mapper.Jackson3MappingProvider
 import com.netflix.graphql.dgs.client.GraphQLRequestOptions.Companion.createCustomObjectMapper
 import org.intellij.lang.annotations.Language
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import tools.jackson.databind.cfg.EnumFeature
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinFeature
+import tools.jackson.module.kotlin.jsonMapper
+import tools.jackson.module.kotlin.kotlinModule
 
 /**
  * Representation of a GraphQL response, which may contain GraphQL errors.
@@ -44,7 +41,7 @@ import org.slf4j.LoggerFactory
 data class GraphQLResponse(
     @Language("json") val json: String,
     val headers: Map<String, List<String>>,
-    private val mapper: ObjectMapper,
+    private val mapper: JsonMapper,
 ) {
     /**
      * A JsonPath DocumentContext. Typically, only used internally.
@@ -54,8 +51,8 @@ data class GraphQLResponse(
             .using(
                 Configuration
                     .builder()
-                    .jsonProvider(JacksonJsonProvider(mapper))
-                    .mappingProvider(JacksonMappingProvider(mapper))
+                    .jsonProvider(Jackson3JsonProvider(mapper))
+                    .mappingProvider(Jackson3MappingProvider(mapper))
                     .build()
                     .addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL),
             ).parse(json)
@@ -159,13 +156,10 @@ data class GraphQLResponse(
         private val logger: Logger = LoggerFactory.getLogger(GraphQLResponse::class.java)
 
         @Deprecated(message = "use GraphQLRequestOptions.createCustomObjectMapper")
-        internal val DEFAULT_MAPPER: ObjectMapper =
+        internal val DEFAULT_MAPPER: JsonMapper =
             jsonMapper {
                 addModule(kotlinModule { enable(KotlinFeature.NullIsSameAsDefault) })
-                addModule(JavaTimeModule())
-                addModule(ParameterNamesModule())
-                addModule(Jdk8Module())
-                enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+                enable(EnumFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
             }
 
         fun getDataPath(path: String): String =

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/MonoGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/MonoGraphQLClient.kt
@@ -16,11 +16,11 @@
 
 package com.netflix.graphql.dgs.client
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.intellij.lang.annotations.Language
 import org.springframework.http.HttpHeaders
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
+import tools.jackson.databind.json.JsonMapper
 import java.util.function.Consumer
 
 /**
@@ -104,7 +104,7 @@ interface MonoGraphQLClient {
         @JvmStatic
         fun createWithWebClient(
             webClient: WebClient,
-            objectMapper: ObjectMapper,
+            objectMapper: JsonMapper,
         ) = WebClientGraphQLClient(webClient, objectMapper)
 
         @JvmStatic

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/RestClientGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/RestClientGraphQLClient.kt
@@ -16,11 +16,11 @@
 
 package com.netflix.graphql.dgs.client
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.intellij.lang.annotations.Language
 import org.springframework.http.HttpHeaders
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.toEntity
+import tools.jackson.databind.json.JsonMapper
 import java.util.function.Consumer
 
 /**
@@ -42,11 +42,11 @@ import java.util.function.Consumer
 class RestClientGraphQLClient(
     private val restClient: RestClient,
     private val headersConsumer: Consumer<HttpHeaders>,
-    private val mapper: ObjectMapper,
+    private val mapper: JsonMapper,
 ) : GraphQLClient {
     constructor(restClient: RestClient) : this(restClient, Consumer { })
 
-    constructor(restClient: RestClient, mapper: ObjectMapper) : this(restClient, Consumer { }, mapper)
+    constructor(restClient: RestClient, mapper: JsonMapper) : this(restClient, Consumer { }, mapper)
 
     constructor(restClient: RestClient, headersConsumer: Consumer<HttpHeaders>) : this(
         restClient,

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/SSESubscriptionGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/SSESubscriptionGraphQLClient.kt
@@ -16,7 +16,6 @@
 
 package com.netflix.graphql.dgs.client
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.netflix.graphql.types.subscription.QueryPayload
 import org.intellij.lang.annotations.Language
 import org.springframework.http.HttpHeaders
@@ -25,6 +24,8 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.toEntityFlux
 import reactor.core.publisher.Flux
 import reactor.core.scheduler.Schedulers
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinModule
 import kotlin.io.encoding.Base64
 
 /*
@@ -40,7 +41,7 @@ class SSESubscriptionGraphQLClient(
     private val url: String,
     private val webClient: WebClient,
 ) : ReactiveGraphQLClient {
-    private val mapper = jacksonObjectMapper()
+    private val mapper = JsonMapper.builder().addModule(KotlinModule.Builder().build()).build()
 
     override fun reactiveExecuteQuery(
         @Language("graphql") query: String,

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClient.kt
@@ -16,7 +16,6 @@
 
 package com.netflix.graphql.dgs.client
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.intellij.lang.annotations.Language
 import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
@@ -24,6 +23,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClient.RequestBodySpec
 import org.springframework.web.reactive.function.client.toEntity
 import reactor.core.publisher.Mono
+import tools.jackson.databind.json.JsonMapper
 import java.util.function.Consumer
 
 /**
@@ -43,7 +43,7 @@ import java.util.function.Consumer
 class WebClientGraphQLClient(
     private val webclient: WebClient,
     private val headersConsumer: Consumer<HttpHeaders>,
-    private val mapper: ObjectMapper,
+    private val mapper: JsonMapper,
 ) : MonoGraphQLClient {
     constructor(webclient: WebClient) : this(webclient, Consumer {})
 
@@ -58,7 +58,7 @@ class WebClientGraphQLClient(
         options: GraphQLRequestOptions,
     ) : this(webclient, Consumer {}, GraphQLRequestOptions.createCustomObjectMapper(options))
 
-    constructor(webclient: WebClient, mapper: ObjectMapper) : this(webclient, Consumer {}, mapper)
+    constructor(webclient: WebClient, mapper: JsonMapper) : this(webclient, Consumer {}, mapper)
 
     constructor(
         webclient: WebClient,

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/WebSocketGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/WebSocketGraphQLClient.kt
@@ -16,8 +16,6 @@
 
 package com.netflix.graphql.dgs.client
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import com.netflix.graphql.types.subscription.GQL_COMPLETE
 import com.netflix.graphql.types.subscription.GQL_CONNECTION_ACK
 import com.netflix.graphql.types.subscription.GQL_CONNECTION_ERROR
@@ -42,6 +40,9 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.publisher.Sinks
 import reactor.util.concurrent.Queues
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinModule
+import tools.jackson.module.kotlin.jacksonTypeRef
 import java.net.URI
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicLong
@@ -62,7 +63,7 @@ class WebSocketGraphQLClient(
     companion object {
         private val DEFAULT_ACKNOWLEDGEMENT_TIMEOUT = Duration.ofSeconds(30)
         private val CONNECTION_INIT_MESSAGE = OperationMessage(GQL_CONNECTION_INIT, null, null)
-        private val MAPPER = jacksonObjectMapper()
+        private val MAPPER = JsonMapper.builder().addModule(KotlinModule.Builder().build()).build()
     }
 
     constructor(
@@ -199,7 +200,7 @@ class OperationMessageWebSocketClient(
     private val client: WebSocketClient,
 ) {
     companion object {
-        private val MAPPER = jacksonObjectMapper()
+        private val MAPPER = JsonMapper.builder().addModule(KotlinModule.Builder().build()).build()
     }
 
     // Sinks are used as buffers, incoming messages from the server are

--- a/graphql-dgs-client/src/test/java/com/netflix/graphql/client/GraphQLResponseJavaTest.java
+++ b/graphql-dgs-client/src/test/java/com/netflix/graphql/client/GraphQLResponseJavaTest.java
@@ -16,9 +16,9 @@
 
 package com.netflix.graphql.client;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.kotlin.KotlinFeature;
-import com.fasterxml.jackson.module.kotlin.KotlinModule;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.module.kotlin.KotlinFeature;
+import tools.jackson.module.kotlin.KotlinModule;
 import com.netflix.graphql.dgs.client.CustomGraphQLClient;
 import com.netflix.graphql.dgs.client.CustomMonoGraphQLClient;
 import com.netflix.graphql.dgs.client.GraphQLClient;
@@ -37,8 +37,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 import reactor.core.publisher.Mono;
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
-
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
@@ -51,7 +49,7 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
-import static com.fasterxml.jackson.module.kotlin.ExtensionsKt.kotlinModule;
+import static tools.jackson.module.kotlin.ExtensionsKt.kotlinModule;
 
 public class GraphQLResponseJavaTest {
 
@@ -162,17 +160,15 @@ public class GraphQLResponseJavaTest {
                 .andRespond(withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
 
-        @SuppressWarnings("deprecation")
-        ObjectMapper objectMapper = Jackson2ObjectMapperBuilder
-                .json()
-                .modulesToInstall(
+        JsonMapper jsonMapper = JsonMapper.builder()
+                .addModule(
                         new KotlinModule.Builder()
                                 .enable(KotlinFeature.NullIsSameAsDefault)
                                 .build()
                 )
                 .build();
 
-        CustomGraphQLClient client = GraphQLClient.createCustom(url, requestExecutor, objectMapper);
+        CustomGraphQLClient client = GraphQLClient.createCustom(url, requestExecutor, jsonMapper);
         GraphQLResponse graphQLResponse = client.executeQuery(query, emptyMap(), "SubmitReview");
         String submittedBy = graphQLResponse.extractValueAsObject("submitReview.submittedBy", String.class);
         assertThat(submittedBy).isEqualTo("abc@netflix.com");
@@ -182,10 +178,10 @@ public class GraphQLResponseJavaTest {
             // Use reflection to access the private 'mapper' field in GraphQLResponse
             Field mapperField = GraphQLResponse.class.getDeclaredField("mapper");
             mapperField.setAccessible(true);
-            ObjectMapper responseMapper = (ObjectMapper) mapperField.get(graphQLResponse);
+            JsonMapper responseMapper = (JsonMapper) mapperField.get(graphQLResponse);
 
-            // Assert that the ObjectMapper in the response is the same as the custom one
-            assertThat(responseMapper).isSameAs(objectMapper);
+            // Assert that the JsonMapper in the response is the same as the custom one
+            assertThat(responseMapper).isSameAs(jsonMapper);
         } catch (Exception e) {
            fail("Shouldn't fail", e);
         }

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/ReactiveWebClientTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/ReactiveWebClientTest.kt
@@ -16,8 +16,6 @@
 
 package com.netflix.graphql.dgs.client
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.jupiter.api.Test
@@ -26,6 +24,7 @@ import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.toEntity
 import reactor.core.publisher.Mono
+import tools.jackson.databind.json.JsonMapper
 import java.time.Duration
 import java.time.LocalDate
 
@@ -63,7 +62,7 @@ class ReactiveWebClientTest {
 
     @Test
     fun testCustomObjectMapper() {
-        val mapper = ObjectMapper().registerModules(JavaTimeModule())
+        val mapper = JsonMapper.builder().build()
         val responseMono =
             CustomMonoGraphQLClient(url, requestExecutor, mapper).reactiveExecuteQuery(
                 $$"{ hello($input: HelloInput!) }",

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/RestClientGraphQLClientTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/RestClientGraphQLClientTest.kt
@@ -16,8 +16,6 @@
 
 package com.netflix.graphql.dgs.client
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
 import com.netflix.graphql.dgs.DgsComponent
 import com.netflix.graphql.dgs.DgsQuery
 import com.netflix.graphql.dgs.DgsRuntimeWiring
@@ -40,11 +38,12 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestClient
+import tools.jackson.databind.cfg.DateTimeFeature
+import tools.jackson.databind.json.JsonMapper
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -135,10 +134,10 @@ class RestClientGraphQLClientTest {
 
     @Test
     fun `Custom ObjectMapper can be supplied to the client`() {
-        val mapper: ObjectMapper =
-            Jackson2ObjectMapperBuilder
-                .json()
-                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        val mapper: JsonMapper =
+            JsonMapper
+                .builder()
+                .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .build()
         val now = LocalDateTime.parse("2024-12-12T12:12:12.12")
         val client = RestClientGraphQLClient(restClient, mapper)

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClientTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClientTest.kt
@@ -16,8 +16,6 @@
 
 package com.netflix.graphql.dgs.client
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
 import com.netflix.graphql.dgs.DgsComponent
 import com.netflix.graphql.dgs.DgsQuery
 import com.netflix.graphql.dgs.DgsRuntimeWiring
@@ -40,13 +38,14 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient
 import reactor.netty.transport.logging.AdvancedByteBufFormat
 import reactor.test.StepVerifier
+import tools.jackson.databind.cfg.DateTimeFeature
+import tools.jackson.databind.json.JsonMapper
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -140,10 +139,10 @@ class WebClientGraphQLClientTest {
 
     @Test
     fun `Custom ObjectMapper can be supplied to the client`() {
-        val mapper: ObjectMapper =
-            Jackson2ObjectMapperBuilder
-                .json()
-                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        val mapper: JsonMapper =
+            JsonMapper
+                .builder()
+                .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .build()
         val now = LocalDateTime.parse("2024-12-12T12:12:12.12")
         val client =

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -34,7 +34,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -77,7 +77,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -119,7 +119,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -162,7 +162,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -223,7 +223,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -266,7 +266,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -317,7 +317,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -360,7 +360,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -401,35 +401,6 @@
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.20.1"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -457,7 +428,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -556,7 +527,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -603,7 +574,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -629,7 +601,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -745,6 +717,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     },
     "kotlinBouncyCastleConfiguration": {
@@ -800,21 +781,117 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
@@ -825,18 +902,6 @@
             "locked": "5.3.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
             "locked": "2.20.1"
         },
         "com.graphql-java:graphql-java": {
@@ -863,7 +928,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -936,7 +1001,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -968,6 +1033,12 @@
         },
         "org.springframework:spring-webflux": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.0.2"
         }
     },
     "swiftExportClasspathResolvable": {
@@ -1011,7 +1082,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1101,7 +1172,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1134,7 +1205,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1212,7 +1283,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1302,7 +1373,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1335,7 +1406,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1394,35 +1465,6 @@
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.20.1"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1450,7 +1492,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1549,7 +1591,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -1596,7 +1638,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -1622,7 +1665,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1729,6 +1772,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     }
 }

--- a/graphql-dgs-example-shared/src/test/java/com/netflix/graphql/dgs/example/shared/datafetcher/SubscriptionDataFetcherTest.java
+++ b/graphql-dgs-example-shared/src/test/java/com/netflix/graphql/dgs/example/shared/datafetcher/SubscriptionDataFetcherTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.graphql.dgs.example.shared.datafetcher;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsExtendedScalarsAutoConfiguration;
 import com.netflix.graphql.dgs.example.shared.types.Stock;
@@ -42,7 +42,7 @@ class SubscriptionDataFetcherTest {
     @Autowired
     DgsQueryExecutor queryExecutor;
 
-    ObjectMapper objectMapper = new ObjectMapper();
+    JsonMapper objectMapper = JsonMapper.builder().build();
 
     @Test
     void stocks() {

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -20,7 +20,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -67,7 +67,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -93,7 +93,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -123,7 +123,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -149,7 +149,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -190,7 +190,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -237,7 +237,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -263,7 +263,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -302,7 +302,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -328,7 +328,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -360,35 +360,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -412,7 +383,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -483,7 +454,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -519,7 +490,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -540,7 +512,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -614,6 +586,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     },
     "kotlinBouncyCastleConfiguration": {
@@ -669,21 +650,117 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
@@ -692,18 +769,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.0"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -725,7 +790,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -779,7 +844,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -802,6 +867,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.0.2"
         }
     },
     "swiftExportClasspathResolvable": {
@@ -839,7 +910,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -901,7 +972,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -923,7 +994,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -977,7 +1048,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1039,7 +1110,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1061,7 +1132,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1099,35 +1170,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1151,7 +1193,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1222,7 +1264,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -1258,7 +1300,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -1279,7 +1322,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1344,6 +1387,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     }
 }

--- a/graphql-dgs-extended-validation/dependencies.lock
+++ b/graphql-dgs-extended-validation/dependencies.lock
@@ -20,7 +20,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -67,7 +67,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -93,7 +93,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -123,7 +123,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -149,7 +149,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -190,7 +190,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -237,7 +237,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -263,7 +263,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -302,7 +302,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -328,7 +328,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -360,35 +360,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -412,7 +383,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -483,7 +454,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -519,7 +490,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -540,7 +512,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -614,6 +586,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     },
     "kotlinBouncyCastleConfiguration": {
@@ -669,21 +650,117 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
@@ -692,18 +769,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.0"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -725,7 +790,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -779,7 +844,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -802,6 +867,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.0.2"
         }
     },
     "swiftExportClasspathResolvable": {
@@ -839,7 +910,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -901,7 +972,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -923,7 +994,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -977,7 +1048,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1039,7 +1110,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1061,7 +1132,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1099,35 +1170,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1151,7 +1193,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1222,7 +1264,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -1258,7 +1300,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -1279,7 +1322,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1344,6 +1387,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     }
 }

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -17,7 +17,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -61,7 +61,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -87,7 +87,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -114,7 +114,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -140,7 +140,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -178,7 +178,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -222,7 +222,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -248,7 +248,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -284,7 +284,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -310,7 +310,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -335,18 +335,6 @@
             ],
             "locked": "5.3.0"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -364,7 +352,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -389,7 +377,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "firstLevelTransitive": [
@@ -421,7 +409,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -465,6 +453,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.0.2"
         }
     },
     "kotlinBouncyCastleConfiguration": {
@@ -520,21 +514,117 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
@@ -543,18 +633,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.0"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -573,7 +651,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -627,7 +705,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -650,6 +728,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.0.2"
         }
     },
     "swiftExportClasspathResolvable": {
@@ -675,7 +759,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -694,7 +778,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "firstLevelTransitive": [
@@ -704,7 +788,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -740,7 +824,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -759,7 +843,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "firstLevelTransitive": [
@@ -769,7 +853,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -794,18 +878,6 @@
             ],
             "locked": "5.3.0"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -823,7 +895,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -848,7 +920,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "firstLevelTransitive": [
@@ -880,7 +952,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -915,6 +987,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.0.2"
         }
     }
 }

--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -66,8 +66,11 @@ dependencies {
             }
         }
         // ---
+        // json-path 3.0.0 ships Jackson 3 providers (Jackson3JsonProvider /
+        // Jackson3MappingProvider). Spring Boot 4 still pins json-path to
+        // 2.9.0 which is Jackson 2 only, so the DGS platform overrides it.
         api("com.jayway.jsonpath:json-path") {
-            version { require("2.9.0") }
+            version { strictly("3.0.0") }
         }
         api("io.projectreactor:reactor-core") {
             version { require("3.6.1") }

--- a/graphql-dgs-reactive/build.gradle.kts
+++ b/graphql-dgs-reactive/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     compileOnly("org.springframework.boot:spring-boot-starter")
     compileOnly("org.springframework:spring-webflux")
 
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("tools.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
     testImplementation("io.projectreactor:reactor-test")

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -17,7 +17,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -44,9 +44,6 @@
         }
     },
     "compileClasspath": {
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -64,7 +61,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -96,7 +93,7 @@
             "locked": "1.10.2"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -106,6 +103,9 @@
         },
         "org.springframework:spring-webflux": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "compileOnlyDependenciesMetadata": {
@@ -117,9 +117,6 @@
         }
     },
     "implementationDependenciesMetadata": {
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -137,7 +134,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -169,10 +166,13 @@
             "locked": "1.10.2"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "jmh": {
@@ -204,7 +204,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -231,9 +231,6 @@
         }
     },
     "jmhCompileClasspath": {
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -251,7 +248,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -283,7 +280,7 @@
             "locked": "1.10.2"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -302,6 +299,9 @@
         },
         "org.springframework:spring-webflux": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "jmhCompileOnlyDependenciesMetadata": {
@@ -313,9 +313,6 @@
         }
     },
     "jmhImplementationDependenciesMetadata": {
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -333,7 +330,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -365,7 +362,7 @@
             "locked": "1.10.2"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -378,6 +375,9 @@
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "jmhRuntimeClasspath": {
@@ -386,18 +386,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.0"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -416,7 +404,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -441,7 +429,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.3.0"
@@ -479,7 +467,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -520,6 +508,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.0.2"
         }
     },
     "kotlinBouncyCastleConfiguration": {
@@ -575,21 +569,117 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
@@ -598,18 +688,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.0"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -628,7 +706,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -685,7 +763,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -705,6 +783,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.0.2"
         }
     },
     "swiftExportClasspathResolvable": {
@@ -713,9 +797,6 @@
         }
     },
     "testCompileClasspath": {
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -733,7 +814,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -752,7 +833,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.3.0"
@@ -771,7 +852,7 @@
             "locked": "1.10.2"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -784,12 +865,12 @@
         },
         "org.springframework.boot:spring-boot-starter-test": {
             "locked": "4.0.0"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "testImplementationDependenciesMetadata": {
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -807,7 +888,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -826,7 +907,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.3.0"
@@ -845,7 +926,7 @@
             "locked": "1.10.2"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -858,6 +939,9 @@
         },
         "org.springframework.boot:spring-boot-starter-test": {
             "locked": "4.0.0"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "testRuntimeClasspath": {
@@ -867,18 +951,6 @@
             ],
             "locked": "5.3.0"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -896,7 +968,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -921,7 +993,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.3.0"
@@ -959,7 +1031,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -991,6 +1063,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.0.2"
         }
     }
 }

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -17,7 +17,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -64,7 +64,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -99,7 +99,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -152,7 +152,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -187,7 +187,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -234,7 +234,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -281,7 +281,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -316,7 +316,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -378,7 +378,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -413,7 +413,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -454,35 +454,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.2.3"
         },
@@ -506,7 +477,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -586,7 +557,7 @@
             "locked": "1.16.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -622,7 +593,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -643,7 +615,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -741,6 +713,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     },
     "kotlinBouncyCastleConfiguration": {
@@ -796,21 +777,117 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
@@ -819,18 +896,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.0"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.2.3"
@@ -852,7 +917,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "project": true
@@ -915,7 +980,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -947,6 +1012,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.0.2"
         }
     },
     "swiftExportClasspathResolvable": {
@@ -984,7 +1055,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1055,7 +1126,7 @@
             "locked": "1.16.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1077,7 +1148,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1152,7 +1223,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1223,7 +1294,7 @@
             "locked": "1.16.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1245,7 +1316,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1304,35 +1375,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.2.3"
         },
@@ -1356,7 +1398,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1436,7 +1478,7 @@
             "locked": "1.16.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -1472,7 +1514,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -1493,7 +1536,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1582,6 +1625,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     }
 }

--- a/graphql-dgs-spring-graphql-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-spring-graphql-example-java-webflux/dependencies.lock
@@ -37,7 +37,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -47,6 +47,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
@@ -137,7 +138,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -185,7 +186,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -195,6 +196,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
@@ -285,7 +287,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -352,7 +354,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -362,6 +364,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
@@ -452,7 +455,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -509,7 +512,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -519,6 +522,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
@@ -609,7 +613,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -656,35 +660,6 @@
             ],
             "locked": "2.20.1"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.github.ben-manes.caffeine:caffeine": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
@@ -707,12 +682,18 @@
             ],
             "locked": "22.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -826,7 +807,7 @@
             "locked": "1.16.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -873,7 +854,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -898,7 +880,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1016,6 +998,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     },
     "kotlinBouncyCastleConfiguration": {
@@ -1071,21 +1062,117 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
@@ -1105,35 +1192,6 @@
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "2.20.1"
         },
@@ -1159,12 +1217,18 @@
             ],
             "locked": "22.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1319,7 +1383,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -1344,7 +1409,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -1441,6 +1506,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     },
     "swiftExportClasspathResolvable": {
@@ -1478,7 +1552,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1488,6 +1562,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
@@ -1553,7 +1628,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
+        },
+        "io.projectreactor:reactor-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
+            ],
+            "locked": "3.8.0"
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.8.0"
@@ -1578,7 +1659,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1635,7 +1716,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1645,6 +1726,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
@@ -1710,7 +1792,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
+        },
+        "io.projectreactor:reactor-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
+            ],
+            "locked": "3.8.0"
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.8.0"
@@ -1735,7 +1823,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1782,35 +1870,6 @@
             ],
             "locked": "2.20.1"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.github.ben-manes.caffeine:caffeine": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
@@ -1833,12 +1892,18 @@
             ],
             "locked": "22.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1952,7 +2017,7 @@
             "locked": "1.16.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -1999,7 +2064,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -2024,7 +2090,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -2133,6 +2199,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     }
 }

--- a/graphql-dgs-spring-graphql-example-java/dependencies.lock
+++ b/graphql-dgs-spring-graphql-example-java/dependencies.lock
@@ -37,7 +37,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -132,7 +132,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -183,7 +183,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -278,7 +278,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -348,7 +348,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -443,7 +443,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -503,7 +503,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -598,7 +598,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -648,35 +648,6 @@
             ],
             "locked": "2.20.1"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.github.ben-manes.caffeine:caffeine": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
@@ -686,6 +657,7 @@
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
@@ -709,7 +681,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -728,6 +700,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "project": true
@@ -840,7 +813,7 @@
             "locked": "1.16.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -890,7 +863,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -918,7 +892,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1077,6 +1051,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     },
     "kotlinBouncyCastleConfiguration": {
@@ -1132,21 +1115,117 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
@@ -1166,35 +1245,6 @@
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "2.20.1"
         },
@@ -1231,7 +1281,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1386,7 +1436,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -1411,7 +1462,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -1511,6 +1562,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     },
     "swiftExportClasspathResolvable": {
@@ -1554,7 +1614,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1572,7 +1632,8 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
             "project": true
         },
@@ -1652,7 +1713,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1687,7 +1748,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1771,7 +1832,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -1789,7 +1850,8 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
             "project": true
         },
@@ -1869,7 +1931,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1904,7 +1966,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1972,35 +2034,6 @@
             ],
             "locked": "2.20.1"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.github.ben-manes.caffeine:caffeine": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
@@ -2010,6 +2043,7 @@
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
@@ -2033,7 +2067,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "firstLevelTransitive": [
@@ -2052,6 +2086,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "project": true
@@ -2164,7 +2199,7 @@
             "locked": "1.16.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -2214,7 +2249,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -2242,7 +2278,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -2392,6 +2428,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     }
 }

--- a/graphql-dgs-spring-graphql-starter-test/dependencies.lock
+++ b/graphql-dgs-spring-graphql-starter-test/dependencies.lock
@@ -55,7 +55,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -92,7 +92,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -171,7 +171,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -217,7 +217,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -256,7 +256,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "firstLevelTransitive": [
@@ -270,7 +270,7 @@
                 "com.netflix.graphql.dgs:dgs-starter-test",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -390,21 +390,117 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
@@ -436,7 +532,7 @@
                 "com.netflix.graphql.dgs:dgs-starter-test",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -505,7 +601,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "firstLevelTransitive": [
@@ -515,7 +611,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -554,7 +650,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "firstLevelTransitive": [
@@ -564,7 +660,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -603,7 +699,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "firstLevelTransitive": [
@@ -617,7 +713,7 @@
                 "com.netflix.graphql.dgs:dgs-starter-test",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"

--- a/graphql-dgs-spring-graphql-starter/dependencies.lock
+++ b/graphql-dgs-spring-graphql-starter/dependencies.lock
@@ -15,12 +15,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "project": true
@@ -115,12 +121,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "project": true
@@ -193,7 +205,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -221,12 +233,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "project": true
@@ -299,7 +317,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -338,12 +356,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "project": true
@@ -438,12 +462,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "project": true
@@ -516,7 +546,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -553,12 +583,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "project": true
@@ -631,7 +667,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -666,35 +702,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -704,12 +711,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "project": true
@@ -773,7 +786,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -808,7 +821,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -828,7 +842,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -901,6 +915,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     },
     "kotlinBouncyCastleConfiguration": {
@@ -956,21 +979,117 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
@@ -987,35 +1106,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1025,12 +1115,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "project": true
@@ -1126,7 +1222,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -1146,7 +1243,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -1198,6 +1295,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     },
     "swiftExportClasspathResolvable": {
@@ -1221,12 +1327,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "project": true
@@ -1281,7 +1393,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1302,7 +1414,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1339,12 +1451,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "project": true
@@ -1399,7 +1517,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1420,7 +1538,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1455,35 +1573,6 @@
             ],
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-client"
-            ],
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1493,12 +1582,18 @@
             ],
             "locked": "25.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "6.0.0"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter": {
             "project": true
@@ -1562,7 +1657,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -1597,7 +1692,8 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
             ],
             "locked": "1.10.2"
         },
@@ -1617,7 +1713,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1681,6 +1777,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql"
+            ],
+            "locked": "3.0.2"
         }
     }
 }

--- a/graphql-dgs-spring-graphql-test/dependencies.lock
+++ b/graphql-dgs-spring-graphql-test/dependencies.lock
@@ -15,7 +15,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -44,7 +44,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -92,7 +92,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -130,7 +130,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -165,13 +165,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -266,21 +266,117 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
@@ -291,7 +387,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -322,13 +418,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -363,13 +459,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -404,13 +500,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"

--- a/graphql-dgs-spring-graphql/build.gradle.kts
+++ b/graphql-dgs-spring-graphql/build.gradle.kts
@@ -22,8 +22,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation("io.micrometer:context-propagation")
     implementation("org.springframework.graphql:spring-graphql")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+    implementation("tools.jackson.module:jackson-module-kotlin")
     implementation("io.micrometer:context-propagation")
     implementation("org.springframework.boot:spring-boot-starter-graphql")
 

--- a/graphql-dgs-spring-graphql/dependencies.lock
+++ b/graphql-dgs-spring-graphql/dependencies.lock
@@ -8,12 +8,6 @@
         }
     },
     "compileClasspath": {
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.2.3"
         },
@@ -34,7 +28,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -76,8 +70,11 @@
             ],
             "locked": "2.2.20"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.10.2"
+        },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -102,6 +99,9 @@
         },
         "org.springframework:spring-webmvc": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "compileOnlyDependenciesMetadata": {
@@ -125,12 +125,6 @@
         }
     },
     "implementationDependenciesMetadata": {
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -148,7 +142,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -184,8 +178,11 @@
             ],
             "locked": "2.2.20"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.10.2"
+        },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -201,6 +198,9 @@
         },
         "org.springframework:spring-web": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "jmh": {
@@ -223,12 +223,6 @@
         }
     },
     "jmhCompileClasspath": {
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.2.3"
         },
@@ -249,7 +243,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -291,8 +285,11 @@
             ],
             "locked": "2.2.20"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.10.2"
+        },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -326,6 +323,9 @@
         },
         "org.springframework:spring-webmvc": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "jmhCompileOnlyDependenciesMetadata": {
@@ -349,12 +349,6 @@
         }
     },
     "jmhImplementationDependenciesMetadata": {
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -372,7 +366,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -408,8 +402,11 @@
             ],
             "locked": "2.2.20"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.10.2"
+        },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -434,6 +431,9 @@
         },
         "org.springframework:spring-web": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "jmhRuntimeClasspath": {
@@ -442,19 +442,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.0"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
-            ],
-            "locked": "2.20.1"
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.2.3"
@@ -476,7 +463,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter-test": {
             "firstLevelTransitive": [
@@ -526,7 +513,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -573,7 +560,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -663,6 +650,13 @@
         },
         "org.springframework:spring-webflux": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ],
+            "locked": "3.0.2"
         }
     },
     "kotlinBouncyCastleConfiguration": {
@@ -718,21 +712,117 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
@@ -741,19 +831,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.0"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
-            ],
-            "locked": "2.20.1"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -772,7 +849,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
@@ -842,7 +919,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -872,6 +949,13 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ],
+            "locked": "3.0.2"
         }
     },
     "swiftExportClasspathResolvable": {
@@ -880,12 +964,6 @@
         }
     },
     "testCompileClasspath": {
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.2.3"
         },
@@ -906,7 +984,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter-test": {
             "firstLevelTransitive": [
@@ -953,7 +1031,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "firstLevelTransitive": [
@@ -966,8 +1044,11 @@
             ],
             "locked": "2.2.20"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.10.2"
+        },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1007,15 +1088,12 @@
         },
         "org.springframework:spring-webflux": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "testImplementationDependenciesMetadata": {
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.2.3"
         },
@@ -1036,7 +1114,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter-test": {
             "firstLevelTransitive": [
@@ -1083,7 +1161,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "firstLevelTransitive": [
@@ -1096,8 +1174,11 @@
             ],
             "locked": "2.2.20"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.10.2"
+        },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1137,6 +1218,9 @@
         },
         "org.springframework:spring-webflux": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "testRuntimeClasspath": {
@@ -1146,19 +1230,6 @@
             ],
             "locked": "5.3.0"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive"
-            ],
-            "locked": "2.20.1"
-        },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.2.3"
         },
@@ -1179,7 +1250,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:dgs-starter-test": {
             "firstLevelTransitive": [
@@ -1229,7 +1300,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -1276,7 +1347,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -1357,6 +1428,13 @@
         },
         "org.springframework:spring-webflux": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ],
+            "locked": "3.0.2"
         }
     }
 }

--- a/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsHeadersSmokeTest.kt
+++ b/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsHeadersSmokeTest.kt
@@ -16,7 +16,6 @@
 
 package com.netflix.graphql.dgs.springgraphql.autoconfig
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.netflix.graphql.dgs.DgsComponent
 import com.netflix.graphql.dgs.DgsExecutionResult
 import com.netflix.graphql.dgs.DgsQuery
@@ -37,6 +36,8 @@ import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.post
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinModule
 import java.util.concurrent.CompletableFuture
 
 @SpringBootTest(
@@ -71,7 +72,12 @@ class DgsHeadersSmokeTest {
 
         mockMvc
             .post("/graphql") {
-                content = jacksonObjectMapper().writeValueAsString(GraphQlRequest(query))
+                content =
+                    JsonMapper
+                        .builder()
+                        .addModule(KotlinModule.Builder().build())
+                        .build()
+                        .writeValueAsString(GraphQlRequest(query))
                 accept = MediaType.APPLICATION_JSON
                 contentType = MediaType.APPLICATION_JSON
             }.andExpect {

--- a/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQlSmokeTest.kt
+++ b/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQlSmokeTest.kt
@@ -16,7 +16,6 @@
 
 package com.netflix.graphql.dgs.springgraphql.autoconfig
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.netflix.graphql.dgs.DgsComponent
 import com.netflix.graphql.dgs.DgsQuery
 import com.netflix.graphql.dgs.InputArgument
@@ -40,6 +39,8 @@ import org.springframework.stereotype.Controller
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.post
 import org.springframework.web.reactive.result.method.annotation.RequestMappingHandlerAdapter
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinModule
 import java.util.function.Consumer
 
 @SpringBootTest(
@@ -82,7 +83,12 @@ class DgsSpringGraphQlSmokeTest {
 
         mockMvc
             .post("/graphql") {
-                content = jacksonObjectMapper().writeValueAsString(GraphQlRequest(query))
+                content =
+                    JsonMapper
+                        .builder()
+                        .addModule(KotlinModule.Builder().build())
+                        .build()
+                        .writeValueAsString(GraphQlRequest(query))
                 accept = MediaType.APPLICATION_JSON
                 contentType = MediaType.APPLICATION_JSON
             }.andExpect {

--- a/graphql-dgs-subscription-types/build.gradle.kts
+++ b/graphql-dgs-subscription-types/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 
     implementation("org.springframework:spring-websocket")
 
-    testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    testImplementation("tools.jackson.module:jackson-module-kotlin")
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/graphql-dgs-subscription-types/dependencies.lock
+++ b/graphql-dgs-subscription-types/dependencies.lock
@@ -27,7 +27,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -50,7 +50,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -98,7 +98,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -130,7 +130,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -152,9 +152,6 @@
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "locked": "25.0"
         },
@@ -162,13 +159,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -196,6 +193,9 @@
         },
         "org.springframework:spring-websocket": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "kotlinBouncyCastleConfiguration": {
@@ -251,21 +251,117 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
@@ -282,7 +378,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -300,9 +396,6 @@
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "locked": "25.0"
         },
@@ -310,13 +403,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -332,15 +425,15 @@
         },
         "org.springframework:spring-websocket": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "testImplementationDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.20"
         },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "locked": "25.0"
         },
@@ -348,13 +441,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -370,14 +463,14 @@
         },
         "org.springframework:spring-websocket": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.20"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
         },
         "com.graphql-java:graphql-java": {
             "locked": "25.0"
@@ -386,13 +479,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -411,6 +504,9 @@
         },
         "org.springframework:spring-websocket": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     }
 }

--- a/graphql-dgs-subscription-types/src/test/kotlin/OperationMessageTest.kt
+++ b/graphql-dgs-subscription-types/src/test/kotlin/OperationMessageTest.kt
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-import com.fasterxml.jackson.databind.JsonMappingException
-import com.fasterxml.jackson.databind.exc.MismatchedInputException
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import com.netflix.graphql.types.subscription.DataPayload
 import com.netflix.graphql.types.subscription.EmptyPayload
 import com.netflix.graphql.types.subscription.GQL_CONNECTION_INIT
@@ -32,6 +28,11 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import tools.jackson.core.JacksonException
+import tools.jackson.databind.exc.MismatchedInputException
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinModule
+import tools.jackson.module.kotlin.jacksonTypeRef
 
 class OperationMessageTest {
     @Test
@@ -51,7 +52,7 @@ class OperationMessageTest {
 
     @Test
     fun rejectsQueryMessageWithoutQuery() {
-        assertFailsToDeserialize<JsonMappingException>(
+        assertFailsToDeserialize<JacksonException>(
             """
             {"type": "connection_init",
              "payload": {
@@ -71,7 +72,7 @@ class OperationMessageTest {
     private fun deserialize(message: String) = MAPPER.readValue(message, jacksonTypeRef<OperationMessage>())
 
     companion object {
-        val MAPPER = jacksonObjectMapper()
+        val MAPPER = JsonMapper.builder().addModule(KotlinModule.Builder().build()).build()
 
         @JvmStatic
         fun validMessages() =

--- a/graphql-dgs/build.gradle.kts
+++ b/graphql-dgs/build.gradle.kts
@@ -31,8 +31,7 @@ dependencies {
     compileOnly("com.github.ben-manes.caffeine:caffeine")
     compileOnly("org.jspecify:jspecify")
 
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+    implementation("tools.jackson.module:jackson-module-kotlin")
     implementation("com.apollographql.federation:federation-graphql-java-support")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -10,7 +10,7 @@
             "locked": "6.0.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -32,12 +32,6 @@
         "com.apollographql.federation:federation-graphql-java-support": {
             "locked": "5.3.0"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.2.3"
         },
@@ -51,7 +45,7 @@
             "locked": "6.0.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -87,7 +81,7 @@
             "locked": "1.10.2"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.jspecify:jspecify": {
             "locked": "1.0.0"
@@ -103,6 +97,9 @@
         },
         "org.springframework:spring-web": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "compileOnlyDependenciesMetadata": {
@@ -126,12 +123,6 @@
         "com.apollographql.federation:federation-graphql-java-support": {
             "locked": "5.3.0"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-error-types"
@@ -142,7 +133,7 @@
             "locked": "6.0.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -172,7 +163,7 @@
             "locked": "1.10.2"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -182,6 +173,9 @@
         },
         "org.springframework:spring-web": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "jmh": {
@@ -206,7 +200,7 @@
             "locked": "6.0.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -228,12 +222,6 @@
         "com.apollographql.federation:federation-graphql-java-support": {
             "locked": "5.3.0"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.2.3"
         },
@@ -247,7 +235,7 @@
             "locked": "6.0.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -283,7 +271,7 @@
             "locked": "1.10.2"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.jspecify:jspecify": {
             "locked": "1.0.0"
@@ -308,6 +296,9 @@
         },
         "org.springframework:spring-web": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "jmhCompileOnlyDependenciesMetadata": {
@@ -331,12 +322,6 @@
         "com.apollographql.federation:federation-graphql-java-support": {
             "locked": "5.3.0"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-error-types"
@@ -347,7 +332,7 @@
             "locked": "6.0.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -377,7 +362,7 @@
             "locked": "1.10.2"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -396,17 +381,14 @@
         },
         "org.springframework:spring-web": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "jmhRuntimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
             "locked": "5.3.0"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -421,7 +403,7 @@
             "locked": "6.0.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -436,7 +418,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.8.0"
@@ -466,7 +448,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -503,6 +485,9 @@
         },
         "org.springframework:spring-web": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "kotlinBouncyCastleConfiguration": {
@@ -558,32 +543,122 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
             "locked": "5.3.0"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -595,7 +670,7 @@
             "locked": "6.0.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -628,7 +703,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -641,6 +716,9 @@
         },
         "org.springframework:spring-web": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "swiftExportClasspathResolvable": {
@@ -652,12 +730,6 @@
         "com.apollographql.federation:federation-graphql-java-support": {
             "locked": "5.3.0"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-error-types"
@@ -671,7 +743,7 @@
             "locked": "6.0.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -686,7 +758,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.8.0"
@@ -713,7 +785,7 @@
             "locked": "1.10.2"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -735,18 +807,15 @@
         },
         "org.springframework:spring-web": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "testImplementationDependenciesMetadata": {
         "com.apollographql.federation:federation-graphql-java-support": {
             "locked": "5.3.0"
         },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
-        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-error-types"
@@ -760,7 +829,7 @@
             "locked": "6.0.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -775,7 +844,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.8.0"
@@ -802,7 +871,7 @@
             "locked": "1.10.2"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -824,17 +893,14 @@
         },
         "org.springframework:spring-web": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     },
     "testRuntimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
             "locked": "5.3.0"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.20.1"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.20.1"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -849,7 +915,7 @@
             "locked": "6.0.0"
         },
         "com.jayway.jsonpath:json-path": {
-            "locked": "2.9.0"
+            "locked": "3.0.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "firstLevelTransitive": [
@@ -864,7 +930,7 @@
             "locked": "1.2.0"
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.8.0"
@@ -894,7 +960,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -922,6 +988,9 @@
         },
         "org.springframework:spring-web": {
             "locked": "7.0.1"
+        },
+        "tools.jackson.module:jackson-module-kotlin": {
+            "locked": "3.0.2"
         }
     }
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/BaseDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/BaseDgsQueryExecutor.kt
@@ -16,16 +16,12 @@
 
 package com.netflix.graphql.dgs.internal
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.jayway.jsonpath.Configuration
 import com.jayway.jsonpath.JsonPath
 import com.jayway.jsonpath.Option
 import com.jayway.jsonpath.ParseContext
-import com.jayway.jsonpath.spi.json.JacksonJsonProvider
-import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider
+import com.jayway.jsonpath.spi.json.Jackson3JsonProvider
+import com.jayway.jsonpath.spi.mapper.Jackson3MappingProvider
 import com.netflix.graphql.dgs.DgsExecutionResult
 import com.netflix.graphql.dgs.context.DgsContext
 import com.netflix.graphql.dgs.exceptions.DgsBadRequestException
@@ -44,6 +40,10 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.util.StringUtils
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.cfg.EnumFeature
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinModule
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
@@ -51,18 +51,25 @@ import java.util.concurrent.CompletionException
 object BaseDgsQueryExecutor {
     private val logger: Logger = LoggerFactory.getLogger(BaseDgsQueryExecutor::class.java)
 
-    val objectMapper: ObjectMapper =
-        jacksonObjectMapper()
-            .registerModule(JavaTimeModule())
-            .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+    val objectMapper: JsonMapper =
+        JsonMapper
+            .builder()
+            .addModule(KotlinModule.Builder().build())
+            .enable(EnumFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            // Jackson 3 flipped the default of FAIL_ON_NULL_FOR_PRIMITIVES to
+            // true. DGS GraphQL responses regularly omit non-selected primitive
+            // fields, which would otherwise break extractAsObject. Restore the
+            // Jackson 2 behaviour of mapping null to the primitive's zero.
+            .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .build()
 
     val parseContext: ParseContext =
         JsonPath.using(
             Configuration
                 .builder()
-                .jsonProvider(JacksonJsonProvider(jacksonObjectMapper()))
-                .mappingProvider(JacksonMappingProvider(objectMapper))
+                .jsonProvider(Jackson3JsonProvider(JsonMapper.builder().addModule(KotlinModule.Builder().build()).build()))
+                .mappingProvider(Jackson3MappingProvider(objectMapper))
                 .build()
                 .addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL),
         )

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/utils/MultipartFileSerializer.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/utils/MultipartFileSerializer.kt
@@ -16,25 +16,25 @@
 
 package com.netflix.graphql.dgs.internal.utils
 
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import org.springframework.web.multipart.MultipartFile
+import tools.jackson.core.JacksonException
+import tools.jackson.core.JsonGenerator
+import tools.jackson.databind.SerializationContext
+import tools.jackson.databind.ser.std.StdSerializer
 import java.io.IOException
 
 /**
  * This class is used only for logging purposes since we cannot serialize a MultipartFile to json otherwise.
  */
 class MultipartFileSerializer : StdSerializer<MultipartFile>(MultipartFile::class.java) {
-    @Throws(IOException::class, JsonProcessingException::class)
+    @Throws(IOException::class, JacksonException::class)
     override fun serialize(
         value: MultipartFile,
         jgen: JsonGenerator,
-        provider: SerializerProvider,
+        provider: SerializationContext,
     ) {
         jgen.writeStartObject()
-        jgen.writeStringField("name", value.originalFilename)
+        jgen.writeStringProperty("name", value.originalFilename)
         jgen.writeEndObject()
     }
 }

--- a/graphql-error-types/dependencies.lock
+++ b/graphql-error-types/dependencies.lock
@@ -24,7 +24,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -46,7 +46,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -88,7 +88,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -119,7 +119,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -142,13 +142,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -228,21 +228,117 @@
         "com.pinterest.ktlint:ktlint-cli-reporter-baseline": {
             "locked": "1.5.0"
         },
+        "com.pinterest.ktlint:ktlint-cli-reporter-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintReporter": {
         "io.github.detekt.sarif4k:sarif4k": {
             "locked": "0.5.0"
         },
+        "io.github.detekt.sarif4k:sarif4k-jvm": {
+            "locked": "0.5.0"
+        },
         "io.github.oshai:kotlin-logging": {
             "locked": "5.1.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "ktlintRuleset": {
+        "com.pinterest.ktlint:ktlint-cli-ruleset-core": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-logger": {
+            "locked": "1.5.0"
+        },
+        "com.pinterest.ktlint:ktlint-rule-engine-core": {
+            "locked": "1.5.0"
+        },
         "com.pinterest.ktlint:ktlint-ruleset-standard": {
             "locked": "1.5.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations": {
+            "locked": "0.18.0"
+        },
+        "dev.drewhamilton.poko:poko-annotations-jvm": {
+            "locked": "0.18.0"
+        },
+        "io.github.oshai:kotlin-logging-jvm": {
+            "locked": "7.0.3"
+        },
+        "org.ec4j.core:ec4j-core": {
+            "locked": "1.1.0"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
+            "locked": "1.10.2"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
         }
     },
     "runtimeClasspath": {
@@ -256,7 +352,7 @@
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.17"
@@ -275,13 +371,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -304,13 +400,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"
@@ -333,13 +429,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.14.6"
+            "locked": "1.14.9"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.20"
         },
         "org.jetbrains:annotations": {
-            "locked": "26.0.2-1"
+            "locked": "26.1.0"
         },
         "org.junit.jupiter:junit-jupiter": {
             "locked": "6.0.1"


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions) first
- [ ] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Migrates the entire DGS Framework from Jackson 2 (`com.fasterxml.jackson.*`) to Jackson 3 (`tools.jackson.*`) so that DGS aligns natively with Spring Boot 4 / Spring Framework 7, where `tools.jackson.databind.json.JsonMapper` replaces `com.fasterxml.jackson.databind.ObjectMapper` as the default mapper.

Issue #2284, also addresses the underlying Jackson 3 conflict reported in #2296.

### What changed

- `BaseDgsQueryExecutor.objectMapper` is now a `JsonMapper` built via the Jackson 3 builder pattern. Public field type changes from `ObjectMapper` to `JsonMapper`.
- JsonPath integration switches to json-path 3.0.0's `Jackson3JsonProvider` and `Jackson3MappingProvider`. The platform BOM bumps json-path from 2.9.0 to 3.0.0; Spring Boot 4's pin is overridden via the `json-path.version` property.
- `graphql-dgs-client` public APIs accept `JsonMapper` instead of `ObjectMapper` across `GraphQLClient`, `MonoGraphQLClient`, `WebClientGraphQLClient`, `RestClientGraphQLClient`, `GraphQLResponse`, and the SSE/WebSocket variants.
- `GraphQLRequestOptions` custom serializer/deserializer extends Jackson 3's `ValueSerializer<T>` / `ValueDeserializer<T>` (renamed from `JsonSerializer` / `JsonDeserializer`). The `serialize` override receives `SerializationContext` (renamed from `SerializerProvider`).
- `MultipartFileSerializer` extends Jackson 3 `StdSerializer`; `writeStringField` is renamed to `writeStringProperty` per the J3 streaming API.
- Drop `jackson-datatype-jdk8`, `jackson-module-parameter-names`, and `jackson-datatype-jsr310` dependencies. JDK 8 / parameter-names / `java.time` support is built into `tools.jackson.databind` 3.x and discovered automatically.
- `READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE` moved from `DeserializationFeature` to `tools.jackson.databind.cfg.EnumFeature` in J3.
- `WRITE_DATES_AS_TIMESTAMPS` moved from `SerializationFeature` to `tools.jackson.databind.cfg.DateTimeFeature` in J3.
- `FAIL_ON_NULL_FOR_PRIMITIVES` is explicitly disabled on `BaseDgsQueryExecutor.objectMapper` because Jackson 3 flipped its default to `true`. DGS GraphQL responses regularly omit non-selected primitive fields and would otherwise break `extractValueAsObject`.
- JPMS `module-info` `requires` clauses updated from `com.fasterxml.jackson.*` to `tools.jackson.*` (databind/core/datatype/module). The annotation module remains `com.fasterxml.jackson.annotation` because Jackson 3 deliberately reuses the existing Jackson 2 `jackson-annotations` artifact (resolved to 2.20 in this build via Spring Boot 4's `jackson-2-bom`) — annotation classes (`JsonProperty`, `JsonCreator`, `JsonIgnoreProperties`, `JsonSubTypes`, `JsonTypeInfo`, etc.) are unchanged in Jackson 3.
- `OperationMessageTest`'s malformed-JSON assertion broadens from `DatabindException` to `JacksonException`; in Jackson 3 parser-level failures throw `StreamReadException`, a sibling of `DatabindException` under `JacksonException`.
- All `dependencies.lock` files regenerated with the new resolutions.

### Breaking changes

- Public APIs that previously accepted `com.fasterxml.jackson.databind.ObjectMapper` (`BaseDgsQueryExecutor.objectMapper`, `GraphQLClient.createCustom`, `WebClientGraphQLClient`, `RestClientGraphQLClient`, `GraphQLResponse`, `MonoGraphQLClient` and the custom variants) now require `tools.jackson.databind.json.JsonMapper`. There is no compatibility shim; callers must migrate.
- Custom client-side `ValueSerializer` / `ValueDeserializer` implementations must extend the new Jackson 3 base classes; `serialize()` takes `SerializationContext`, `deserialize()` takes `DeserializationContext`.
- json-path is forced to 3.0.0 (overrides Spring Boot 4's 2.9.0 pin); consumers that use json-path APIs transitively through DGS may need to adjust to json-path 3.x.

### Verification

- `./gradlew check` is green (compile, ktlint, all tests across every module).
- `grep -rn "com.fasterxml.jackson" --include='*.kt' --include='*.kts' --include='*.java' .` returns only `jackson-annotations` references, which is intentional — Jackson 3 deliberately reuses the Jackson 2 annotations artifact.

Issue #2284

Alternatives considered
----

- **Dual-stack with `spring-boot-jackson2` compatibility shim**: keeps Jackson 2 alongside Jackson 3 via the Spring Boot 4 bridge module. Rejected because the goal is for DGS to natively align with the Spring Boot 4 default (Jackson 3) without forcing every consumer to drag in the deprecated Jackson 2 module. `org.springframework.boot.jackson2.autoconfigure.Jackson2AutoConfiguration` is annotated `@Deprecated(since = "4.0.0", forRemoval = true)` and the [Spring Boot Javadoc](https://docs.spring.io/spring-boot/api/java/org/springframework/boot/jackson2/autoconfigure/Jackson2AutoConfiguration.html) states it will be removed in Spring Boot 4.3.0 in favor of Jackson 3.
- **Hybrid migration retaining `ObjectMapper`-typed public APIs as deprecated**: would soften the break but contradicts the request in #2284 for native Jackson 3 support. The annotation classes are reused as-is precisely because they did not need to change; the rest of the API rename was unavoidable per the Jackson 3 design.
- **Wait for an upstream maintainer-driven migration**: #2284 has been open since 2026-03 with no implementation progress and #2296 confirms the current 11.1.x line is incoherent under Spring Boot 4. Submitting this PR unblocks downstream Spring Boot 4 adopters today.
