### PR TITLE
Exclude dgsCoroutineDispatcher from being injected unless explicitly qualified for

### DIFF
--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
@@ -516,7 +516,7 @@ open class DgsSpringGraphQLAutoConfiguration(
      * Defaults to [Dispatchers.Unconfined] which runs coroutines immediately on the calling thread.
      * Override this bean to customize the dispatcher for your specific use case.
      */
-    @Bean
+    @Bean(defaultCandidate = false)
     @Qualifier("dgsCoroutineDispatcher")
     @ConditionalOnMissingBean(name = ["dgsCoroutineDispatcher"])
     open fun dgsCoroutineDispatcher(): CoroutineDispatcher = Dispatchers.Unconfined


### PR DESCRIPTION
This allows users to still override the coroutine dispatcher used within DGS if they want, but also allows them to define other coroutine dispatchers that they inject in user code without the need to use `@Primary` or `@Qualifier`