### PR TITLE
fix: close the data loader registry in SpringGraphQLDgsQueryExecutor

### DIFF
--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/SpringGraphQLDgsQueryExecutor.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/SpringGraphQLDgsQueryExecutor.kt
@@ -31,6 +31,7 @@ import com.netflix.graphql.dgs.internal.DgsQueryExecutorRequestCustomizer
 import com.netflix.graphql.dgs.internal.DgsWebMvcRequestData
 import com.netflix.graphql.dgs.json.DgsJsonMapper
 import graphql.ExecutionResult
+import org.dataloader.DataLoaderRegistry
 import org.springframework.graphql.ExecutionGraphQlService
 import org.springframework.graphql.support.DefaultExecutionGraphQlRequest
 import org.springframework.http.HttpHeaders
@@ -69,16 +70,26 @@ class SpringGraphQLDgsQueryExecutor(
         val httpRequest = requestCustomizer.apply(webRequest ?: RequestContextHolder.getRequestAttributes() as? WebRequest, headers)
         val dgsContext = dgsContextBuilder.build(DgsWebMvcRequestData(request.extensions, headers, httpRequest))
 
+        // A ticker mode registry keeps rescheduling itself until it is closed, so the registry built
+        // for this request has to be closed once the request completes, the same way the webmvc and
+        // webflux interceptors do it. Otherwise every query leaves a task behind on the shared
+        // scheduled executor for the rest of the JVM's life.
+        var dataLoaderRegistry: DataLoaderRegistry? = null
+
         request.configureExecutionInput { e, builder ->
-            val dataLoaderRegistry = dgsDataLoaderProvider.buildRegistryWithContextSupplier { e.graphQLContext }
+            val registry = dgsDataLoaderProvider.buildRegistryWithContextSupplier { e.graphQLContext }
+            dataLoaderRegistry = registry
             builder
                 .graphQLContext(dgsContext)
-                .dataLoaderRegistry(dataLoaderRegistry)
+                .dataLoaderRegistry(registry)
                 .build()
         }
 
         val response =
-            executionService.execute(request).block() ?: throw IllegalStateException("Unexpected null response from Spring GraphQL client")
+            executionService
+                .execute(request)
+                .doFinally { (dataLoaderRegistry as? AutoCloseable)?.close() }
+                .block() ?: throw IllegalStateException("Unexpected null response from Spring GraphQL client")
 
         return response.executionResult
     }

--- a/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/SpringGraphQLDgsQueryExecutorTest.kt
+++ b/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/SpringGraphQLDgsQueryExecutorTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.springgraphql
+
+import com.netflix.graphql.dgs.internal.DefaultDgsGraphQLContextBuilder
+import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
+import com.netflix.graphql.dgs.internal.Jackson3DgsJsonMapper
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.dataloader.registries.ScheduledDataLoaderRegistry
+import org.junit.jupiter.api.Test
+import org.springframework.graphql.ExecutionGraphQlRequest
+import org.springframework.graphql.ExecutionGraphQlResponse
+import org.springframework.graphql.ExecutionGraphQlService
+import reactor.core.publisher.Mono
+import java.util.Optional
+import java.util.function.Supplier
+
+class SpringGraphQLDgsQueryExecutorTest {
+    private val dataLoaderRegistry = mockk<ScheduledDataLoaderRegistry>(relaxed = true)
+
+    private val dataLoaderProvider =
+        mockk<DgsDataLoaderProvider> {
+            every { buildRegistryWithContextSupplier(any<Supplier<Any>>()) } returns dataLoaderRegistry
+        }
+
+    /**
+     * A ticker mode registry reschedules itself until it is closed, so failing to close it leaks a
+     * task on the shared scheduled executor for every executed query.
+     */
+    @Test
+    fun `closes the data loader registry once the query completes`() {
+        val queryExecutor = queryExecutor { request -> Mono.just(responseFor(request)) }
+
+        queryExecutor.execute("{ __typename }")
+
+        verify(exactly = 1) { dataLoaderRegistry.close() }
+    }
+
+    @Test
+    fun `closes the data loader registry when execution fails`() {
+        val queryExecutor =
+            queryExecutor { request ->
+                request.toExecutionInput()
+                Mono.error(RuntimeException("boom"))
+            }
+
+        assertThatThrownBy { queryExecutor.execute("{ __typename }") }.hasMessage("boom")
+
+        verify(exactly = 1) { dataLoaderRegistry.close() }
+    }
+
+    private fun queryExecutor(executionService: ExecutionGraphQlService): SpringGraphQLDgsQueryExecutor =
+        SpringGraphQLDgsQueryExecutor(
+            executionService = executionService,
+            dgsContextBuilder = DefaultDgsGraphQLContextBuilder(Optional.empty()),
+            dgsDataLoaderProvider = dataLoaderProvider,
+            dgsJsonMapper = Jackson3DgsJsonMapper(),
+            graphQLContextContributors = emptyList(),
+        )
+
+    private fun responseFor(request: ExecutionGraphQlRequest): ExecutionGraphQlResponse {
+        // Building the execution input is what applies the configurer that creates the registry.
+        request.toExecutionInput()
+        return mockk(relaxed = true)
+    }
+}


### PR DESCRIPTION
## Problem

`SpringGraphQLDgsQueryExecutor.execute()` builds a data loader registry per request via `DgsDataLoaderProvider.buildRegistryWithContextSupplier` and never closes it. The other execution paths all close theirs:

- `DgsWebMvcGraphQLInterceptor` closes it after `chain.next(request)` completes (both the async-dispatch and blocking branches)
- `DgsWebFluxGraphQLInterceptor` closes it in `doFinally`
- `BaseDgsQueryExecutor.baseExecute` closes it in `whenComplete`

`DefaultDgsDataLoaderProvider` always returns a `ScheduledDataLoaderRegistry`, and with `dgs.graphql.dataloader.ticker-mode-enabled` the registry keeps rescheduling itself until it is closed. Every query executed through the `DgsQueryExecutor` bean therefore leaves a task behind on the shared scheduled executor for the rest of the JVM's life.

This is particularly painful in test suites, where `DgsQueryExecutor` is the primary entry point. In one of our suites executing 275 queries in a single JVM, the leaked ticker tasks grew to 21.7% of all JFR execution samples; closing the registry brought that down to 0.8% and cut wall time by 22% on a two-core container.

## Fix

Track the registry created by the execution input configurer and close it from `doFinally` on the execution `Mono` — the same pattern `DgsWebMvcGraphQLInterceptor` uses for async dispatch — so the registry is also released when execution fails or is cancelled.

## Testing

Added `SpringGraphQLDgsQueryExecutorTest` verifying the registry is closed exactly once on successful completion and on execution failure. Both pass, and `lintKotlin` passes on the module.
