### PR TITLE
Update Java toolchain requirement in contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,9 +86,8 @@ The DGS codebases are Kotlin based. We strongly recommend using Intellij because
 Gradle. You can use the free [Intellij Community Edition](https://www.jetbrains.com/idea/download/).
 
 Clone and open the project using the "project from version control feature" and let Gradle import all dependencies. Note
-that we build on Java 8, so a Java 8 JDK is required. If you don't have a JDK, you can use [sdkman](https://sdkman.io/)
-or [Intellij](https://www.jetbrains.com/help/idea/sdk.html) to install one. Because almost all the code is Kotlin, we
-don't miss any language features of newer Java releases while supporting a broad range of older releases.
+that the build uses a Java 17 toolchain, so JDK 17 is required. If you don't have a JDK, you can use
+[sdkman](https://sdkman.io/) or [Intellij](https://www.jetbrains.com/help/idea/sdk.html) to install one.
 
 Code conventions
 -----


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions) first. A discussion is not needed for this factual documentation correction.
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases. Not applicable: this changes contributor documentation only.

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other: Documentation

Changes in this PR
----

Update the contributor setup instructions from Java 8 to JDK 17, matching the current `jvmToolchain(17)` build configuration and Java 17 CI environment. Remove the outdated explanation about supporting older Java releases.

Validation:
- Ran `git diff --check`.
- Confirmed the Gradle build config uses `jvmToolchain(17)`.
- Confirmed CI configures Java 17.

Issue #

N/A

Alternatives considered
----

Keeping the Java 8 guidance is inconsistent with both the current Gradle toolchain and CI configuration.
