### PR TITLE
fix: skip pre-ack messages during WebSocketGraphQLClient handshake

### DIFF
--- a/graphql-dgs-client/src/main/java/module-info.java
+++ b/graphql-dgs-client/src/main/java/module-info.java
@@ -2,6 +2,7 @@ module com.netflix.graphql.dgs.client {
     requires kotlin.stdlib;
     requires com.fasterxml.jackson.databind;
     requires org.jetbrains.annotations;
+    requires org.slf4j;
     requires spring.web;
 
     requires reactor.core;

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/WebSocketGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/WebSocketGraphQLClient.kt
@@ -32,6 +32,7 @@ import com.netflix.graphql.types.subscription.OperationMessage
 import com.netflix.graphql.types.subscription.QueryPayload
 import graphql.GraphQLException
 import org.intellij.lang.annotations.Language
+import org.slf4j.LoggerFactory
 import org.springframework.web.reactive.socket.WebSocketHandler
 import org.springframework.web.reactive.socket.WebSocketMessage
 import org.springframework.web.reactive.socket.WebSocketSession
@@ -60,6 +61,7 @@ class WebSocketGraphQLClient(
     private val acknowledgementTimeout: Duration = DEFAULT_ACKNOWLEDGEMENT_TIMEOUT,
 ) : ReactiveGraphQLClient {
     companion object {
+        private val logger = LoggerFactory.getLogger(WebSocketGraphQLClient::class.java)
         private val DEFAULT_ACKNOWLEDGEMENT_TIMEOUT = Duration.ofSeconds(30)
         private val CONNECTION_INIT_MESSAGE = OperationMessage(GQL_CONNECTION_INIT, null, null)
         private val MAPPER = jacksonObjectMapper()
@@ -149,14 +151,22 @@ class WebSocketGraphQLClient(
             client.send(CONNECTION_INIT_MESSAGE)
             client
                 .receive()
-                .take(1)
-                .map { message ->
-                    if (message.type == GQL_CONNECTION_ACK) {
-                        message
-                    } else {
-                        throw GraphQLException("Acknowledgement expected from server, received $message")
+                // Some servers (Hasura being a known example) emit keep-alive messages before
+                // the connection ack. Skip anything that isn't the ack and keep waiting for it,
+                // except a connection error, which fails the handshake right away.
+                .handle<OperationMessage> { message, sink ->
+                    when (message.type) {
+                        GQL_CONNECTION_ACK -> sink.next(message)
+                        GQL_CONNECTION_ERROR ->
+                            sink.error(GraphQLException("Connection rejected by server, received $message"))
+                        else ->
+                            logger.debug(
+                                "Skipping message received before connection acknowledgement: {}",
+                                message,
+                            )
                     }
-                }.timeout(acknowledgementTimeout)
+                }.next()
+                .timeout(acknowledgementTimeout)
                 .then()
         }
 

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/WebSocketGraphQLClientTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/WebSocketGraphQLClientTest.kt
@@ -34,7 +34,9 @@ package com.netflix.graphql.dgs.client
 import com.netflix.graphql.types.subscription.DataPayload
 import com.netflix.graphql.types.subscription.GQL_COMPLETE
 import com.netflix.graphql.types.subscription.GQL_CONNECTION_ACK
+import com.netflix.graphql.types.subscription.GQL_CONNECTION_ERROR
 import com.netflix.graphql.types.subscription.GQL_CONNECTION_INIT
+import com.netflix.graphql.types.subscription.GQL_CONNECTION_KEEP_ALIVE
 import com.netflix.graphql.types.subscription.GQL_DATA
 import com.netflix.graphql.types.subscription.GQL_ERROR
 import com.netflix.graphql.types.subscription.GQL_START
@@ -67,6 +69,7 @@ class WebSocketGraphQLClientTest {
     companion object {
         private val VERIFY_TIMEOUT = Duration.ofSeconds(10)
         private val CONNECTION_ACK_MESSAGE = OperationMessage(GQL_CONNECTION_ACK, null, null)
+        private val CONNECTION_KEEP_ALIVE_MESSAGE = OperationMessage(GQL_CONNECTION_KEEP_ALIVE, null, null)
         private val TEST_DATA_A = mapOf("a" to 1, "b" to "hello", "c" to false)
         private val TEST_DATA_B = mapOf("a" to 2, "b" to null, "c" to true)
         private val TEST_DATA_C = mapOf("a" to 3, "b" to "world", "c" to false)
@@ -101,8 +104,48 @@ class WebSocketGraphQLClientTest {
     }
 
     @Test
-    fun errorsIfMessageOtherThanAckFromServer() {
+    fun skipsKeepAliveMessageBeforeAck() {
+        // Servers like Hasura emit a keep-alive right after connecting, before the ack.
+        // The handshake must wait for the ack instead of failing on the keep-alive.
+        server.next(CONNECTION_KEEP_ALIVE_MESSAGE)
+        server.next(CONNECTION_ACK_MESSAGE)
         server.next(dataMessage(TEST_DATA_A, "1"))
+        server.next(completeMessage("1"))
+
+        val responses = client.reactiveExecuteQuery("", emptyMap())
+        StepVerifier
+            .create(responses)
+            .expectSubscription()
+            .expectNextMatches { it.extractValue<Int>("a") == 1 }
+            .expectComplete()
+            .verify(VERIFY_TIMEOUT)
+
+        verify { subscriptionsClient.send(OperationMessage(GQL_CONNECTION_INIT, null, null)) }
+    }
+
+    @Test
+    fun skipsStrayDataMessageBeforeAck() {
+        // No subscription has been started before the ack, so any data received first
+        // cannot belong to this client and gets skipped while waiting for the ack.
+        server.next(dataMessage(TEST_DATA_A, "99"))
+        server.next(CONNECTION_ACK_MESSAGE)
+        server.next(dataMessage(TEST_DATA_B, "1"))
+        server.next(completeMessage("1"))
+
+        val responses = client.reactiveExecuteQuery("", emptyMap())
+        StepVerifier
+            .create(responses)
+            .expectSubscription()
+            .expectNextMatches { it.extractValue<Int>("a") == 2 }
+            .expectComplete()
+            .verify(VERIFY_TIMEOUT)
+    }
+
+    @Test
+    fun errorsOnConnectionErrorBeforeAck() {
+        // A connection error rejects the connection init, so the handshake fails right away
+        // instead of skipping it and waiting for an ack that will never come.
+        server.next(OperationMessage(GQL_CONNECTION_ERROR, "Authentication error", null))
 
         val responses = client.reactiveExecuteQuery("", emptyMap())
         StepVerifier


### PR DESCRIPTION
Fixes #1328

## What

Per the subscriptions-transport-ws protocol the server answers `connection_init` with `connection_ack`, but some servers emit other messages first. Hasura, for example, sends a `ka` (keep-alive) immediately after connecting (hasura/graphql-engine#7002). `WebSocketGraphQLClient.doHandshake()` takes the first message off the wire and throws if it isn't the ack, so any subscription against such a server fails during the handshake:

```
graphql.GraphQLException: Acknowledgement expected from server, received OperationMessage(type=ka, payload=null, id=)
```

## Fix

The handshake now keeps waiting for the ack and skips anything else that arrives first, logging skipped messages at debug level, still bounded by the same acknowledgement timeout.

One case is not skipped: `connection_error`. It means the server rejected the `connection_init`, so the handshake now fails right away with the server's payload instead of sitting behind the timeout.

Added `requires org.slf4j` to the module descriptor for the new debug logging (slf4j-api was already on the compile classpath).

## Tests

Updated `WebSocketGraphQLClientTest`:

- `skipsKeepAliveMessageBeforeAck` — the Hasura case from #1328: `ka` then `ack`, the subscription proceeds and receives data
- `skipsStrayDataMessageBeforeAck` — a data message before the ack is ignored rather than fatal (no subscription exists yet at that point, so it can't belong to this client)
- `errorsOnConnectionErrorBeforeAck` — `connection_error` still fails the handshake fast

The previous `errorsIfMessageOtherThanAckFromServer` test asserted the strict behavior the issue asks to change, so it is replaced by the tests above. `timesOutIfNoAckFromServer` is unchanged and still passes: with no ack at all, the handshake times out as before.

Both new skip tests fail against the current implementation, and the full `:graphql-dgs-client:test` suite passes with the fix.
