### PR TITLE
fix(deps): bump Spring Boot BOM to patch CVE-2026-41854 (Spring Framework SSRF)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ allprojects {
     // and suggest an upgrade. The only exception currently are those defined
     // in buildSrc, most likely because the variables are used in plugins as well
     // as dependencies. e.g. KOTLIN_VERSION
-    extra["sb.version"] = "4.0.0"
+    extra["sb.version"] = "4.0.8"
     extra["kotlin.version"] = Versions.KOTLIN_VERSION
     extra["json-path.version"] = "3.0.0"
 }


### PR DESCRIPTION
Automated dependency bump to address a disclosed CVE.

- **CVE:** CVE-2026-41854
- **Advisory:** https://github.com/advisories/GHSA-7m2p-62gw-p8qq
- **Severity:** moderate (CVSS 3.1 `AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N`)
- **Package:** `org.springframework:spring-web` `7.0.1` → `7.0.9` (via the `spring-boot-dependencies` BOM, `4.0.0` → `4.0.8`)

Due to incorrect host parsing, applications that rely on `UriComponentsBuilder` to parse and validate an externally provided URL string may be exposed to a server-side request forgery (SSRF) attack. Spring Framework 7.0.0–7.0.7 is affected; fixed in 7.0.8. `spring-web` is currently pinned to `7.0.1` via `extra["sb.version"]` in the root `build.gradle.kts` (Spring Boot `4.0.0`'s BOM).

This PR bumps `sb.version` to `4.0.8`, the latest `4.0.x` (same-major) release, whose BOM pins `spring-framework.version` to `7.0.9` — independently verified clean against the OSV database (0 advisories for `spring-web@7.0.9`).

**Note on `dependencies.lock`:** this repo uses Netflix's Nebula dependency-lock plugin (`dependencies.lock` per module), which requires `./gradlew generateLock saveLock` (network + full dependency resolution) to regenerate. That tooling wasn't available in the environment this PR was prepared in, so only the `build.gradle.kts` version source is changed here — the lock files will need regenerating as part of your normal release/lock-update process before this is mergeable. Happy to iterate if there's a preferred way to do that from CI.

Detected by direct OSV API queries against the runtime dependency versions declared in `graphql-dgs/dependencies.lock` (osv-scanner itself doesn't parse the Nebula lock format, so this was a targeted supplemental check rather than a full-repo scan).

---
Filed by [Aeon](https://github.com/aeonfun/aeon).